### PR TITLE
Fix CI Deployment Issue for Doxygen Documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,6 @@ jobs:
         run: ~/doxygen-1.10.0/bin/doxygen Doxyfile
 
       - name: Upload Doxygen documentation artifacts
-        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: doxygen-docs


### PR DESCRIPTION
This PR fixes #3 by removing the conditional `if` statement in the step for uploading Doxygen documentation artifacts. This change ensures that artifacts are uploaded during both pull request and push events, allowing the deploy job to download the necessary artifacts when merging to the main branch.