### PR TITLE
Refactor Client to Support Async Method Calls

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,7 @@ IncludeBlocks: Regroup
 IncludeCategories:
   - Regex: '^"jsonrpc/.*"'
     Priority: 3
-  - Regex: "^<(jsonrpc|nlohmann|spdlog|BS_thread_pool|catch2).*>"
+  - Regex: "^<(jsonrpc|nlohmann|fmt|spdlog|BS_thread_pool|catch2).*>"
     Priority: 2
   - Regex: "^<.*>"
     Priority: 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ project(jsonrpc VERSION 1.0.0 LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+# Set C++ Compiler Launcher
+set(CMAKE_C_COMPILER_LAUNCHER ccache)
+set(CMAKE_CXX_COMPILER_LAUNCHER ccache)
+
 # Source files
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -23,7 +23,7 @@ class JsonRpcConan(ConanFile):
     # Declare package dependencies
     requires = [
         "nlohmann_json/3.11.2",
-        "spdlog/1.9.2",
+        "spdlog/1.14.1",
         "bshoshany-thread-pool/4.1.0"
     ]
 
@@ -48,11 +48,7 @@ class JsonRpcConan(ConanFile):
         tc = CMakeToolchain(self)
         tc.user_presets_path = 'ConanPresets.json'
 
-        # Set up ccache and Ninja
-        tc.variables["CMAKE_C_COMPILER_LAUNCHER"] = "ccache"
-        tc.variables["CMAKE_CXX_COMPILER_LAUNCHER"] = "ccache"
         tc.generator = "Ninja"
-
         tc.generate()
 
     def build(self):

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -28,10 +28,13 @@ bool Client::isRunning() const {
   return running_;
 }
 
+bool Client::HasPendingRequests() const {
+  std::lock_guard<std::mutex> lock(pendingRequestsMutex_);
+  return !pendingRequests_.empty();
+}
+
 void Client::Listener() {
   while (running_) {
-    spdlog::debug("JSON-RPC client listener running and expecting {} responses",
-        expectedResponses_);
     if (expectedResponses_ > 0) {
       std::string response = transport_->ReadResponse();
       HandleResponse(response);
@@ -47,43 +50,41 @@ nlohmann::json Client::SendMethodCall(
   return SendRequest(request);
 }
 
+std::future<nlohmann::json> Client::SendMethodCallAsync(
+    const std::string &method, std::optional<nlohmann::json> params) {
+  Request request(method, std::move(params), false,
+      [this]() { return GetNextRequestId(); });
+  return SendRequestAsync(request);
+}
+
 void Client::SendNotification(
     const std::string &method, std::optional<nlohmann::json> params) {
   Request request(
       method, std::move(params), true, [this]() { return GetNextRequestId(); });
-  // Notifications do not expect a response
   transport_->SendRequest(request.Dump());
 }
 
 nlohmann::json Client::SendRequest(const Request &request) {
-  if (request.RequiresResponse()) {
-    std::promise<nlohmann::json> responsePromise;
-    auto futureResponse = responsePromise.get_future();
+  auto futureResponse = SendRequestAsync(request);
+  return futureResponse.get();
+}
 
-    {
-      std::lock_guard<std::mutex> lock(pendingRequestsMutex_);
-      pendingRequests_[request.GetKey()] = std::move(responsePromise);
-    }
-    expectedResponses_++;
+std::future<nlohmann::json> Client::SendRequestAsync(const Request &request) {
+  assert(request.RequiresResponse() && "SendRequestAsync called for a request "
+                                       "that does not require a response.");
 
-    transport_->SendRequest(request.Dump());
+  std::promise<nlohmann::json> responsePromise;
+  auto futureResponse = responsePromise.get_future();
 
-    // Block until the promise is fulfilled and return the response
-    futureResponse.wait();
-    auto response = futureResponse.get();
-
-    {
-      std::lock_guard<std::mutex> lock(pendingRequestsMutex_);
-      pendingRequests_.erase(request.GetKey());
-    }
-
-    return response;
-  } else {
-    // No response expected, just send the request
-    transport_->SendRequest(request.Dump());
-    return nlohmann::json(); // Return an empty JSON object since no response is
-                             // expected
+  {
+    std::lock_guard<std::mutex> lock(pendingRequestsMutex_);
+    pendingRequests_[request.GetKey()] = std::move(responsePromise);
   }
+  expectedResponses_++;
+
+  transport_->SendRequest(request.Dump());
+
+  return futureResponse;
 }
 
 int Client::GetNextRequestId() {

--- a/tests/client/test_client.cpp
+++ b/tests/client/test_client.cpp
@@ -7,6 +7,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
+#include <fmt/core.h>
 #include <nlohmann/json.hpp>
 
 #include "jsonrpc/client/client.hpp"
@@ -26,7 +27,7 @@ public:
 
   std::string ReadResponse() override {
     if (responses.empty()) {
-      return ""; // Simulate no response or timeout
+      return "";
     }
     std::string response = responses.front();
     responses.pop();
@@ -44,6 +45,7 @@ TEST_CASE("Client starts and stops correctly", "[Client]") {
 
   client.Start();
   REQUIRE(client.isRunning() == true);
+  REQUIRE(client.HasPendingRequests() == false);
 
   client.Stop();
   REQUIRE(client.isRunning() == false);
@@ -56,7 +58,9 @@ TEST_CASE("Client handles responses correctly", "[Client]") {
   Client client(std::move(transport));
   client.Start();
 
+  REQUIRE(client.HasPendingRequests() == false);
   auto response = client.SendMethodCall("test_method");
+  REQUIRE(client.HasPendingRequests() == false);
 
   REQUIRE(response["result"] == "success");
 
@@ -74,6 +78,7 @@ TEST_CASE(
   client.SendNotification(
       "notify_event", nlohmann::json({{"param1", "value1"}}));
 
+  REQUIRE(client.HasPendingRequests() == false);
   REQUIRE(transportPtr->sentRequests.size() == 1);
   REQUIRE(
       transportPtr->sentRequests[0].find("notify_event") != std::string::npos);
@@ -91,11 +96,92 @@ TEST_CASE("Client handles valid JSON-RPC response", "[Client]") {
   Client client(std::move(transport));
   client.Start();
 
+  REQUIRE(client.HasPendingRequests() == false);
   auto response = client.SendMethodCall("getData");
+  REQUIRE(client.HasPendingRequests() == false);
 
   REQUIRE(response.contains("result"));
   REQUIRE(response["result"].contains("data"));
   REQUIRE(response["result"]["data"] == "success");
+
+  client.Stop();
+}
+
+TEST_CASE("Client handles in-order responses correctly", "[Client][InOrder]") {
+  auto transport = std::make_unique<MockTransport>();
+  MockTransport *transportPtr = transport.get();
+
+  for (int i = 0; i < 10; ++i) {
+    std::string response = fmt::format(
+        R"({{"jsonrpc":"2.0","result":{{"data":"success_{}"}},"id":{}}})", i,
+        i);
+    transportPtr->SetResponse(response);
+  }
+
+  Client client(std::move(transport));
+  client.Start();
+
+  for (int i = 0; i < 10; ++i) {
+    REQUIRE(client.HasPendingRequests() == false);
+    auto response = client.SendMethodCall("getData");
+    REQUIRE(client.HasPendingRequests() == false);
+    REQUIRE(response["result"]["data"] == "success_" + std::to_string(i));
+  }
+
+  client.Stop();
+}
+
+TEST_CASE("Client handles async method calls correctly", "[Client][Async]") {
+  auto transport = std::make_unique<MockTransport>();
+  MockTransport *transportPtr = transport.get();
+
+  transportPtr->SetResponse(
+      R"({"jsonrpc":"2.0","result":"async_success","id":0})");
+
+  Client client(std::move(transport));
+  client.Start();
+
+  auto futureResponse = client.SendMethodCallAsync("async_test_method");
+
+  REQUIRE(futureResponse.wait_for(std::chrono::seconds(1)) ==
+          std::future_status::ready);
+
+  nlohmann::json response = futureResponse.get();
+
+  REQUIRE(client.HasPendingRequests() == false);
+  REQUIRE(response["result"] == "async_success");
+
+  client.Stop();
+}
+
+TEST_CASE("Client handles multiple async method calls concurrently",
+    "[Client][Async]") {
+  auto transport = std::make_unique<MockTransport>();
+  MockTransport *transportPtr = transport.get();
+
+  for (int i = 0; i < 5; ++i) {
+    transportPtr->SetResponse(fmt::format(
+        R"({{"jsonrpc":"2.0","result":"success_{}","id":{}}})", i, i));
+  }
+
+  Client client(std::move(transport));
+  client.Start();
+
+  std::vector<std::future<nlohmann::json>> futures;
+
+  for (int i = 0; i < 5; ++i) {
+    futures.push_back(
+        client.SendMethodCallAsync(fmt::format("async_test_method_{}", i)));
+  }
+
+  for (int i = 0; i < 5; ++i) {
+    REQUIRE(futures[i].wait_for(std::chrono::seconds(1)) ==
+            std::future_status::ready);
+    nlohmann::json response = futures[i].get();
+    REQUIRE(response["result"] == fmt::format("success_{}", i));
+  }
+
+  REQUIRE(client.HasPendingRequests() == false);
 
   client.Stop();
 }


### PR DESCRIPTION
This PR introduces `SendMethodCallAsync` to the client, refactors the client code, and adds new unit tests. It also updates some string handling with `fmt` for better readability.

## Added

- `SendMethodCallAsync` method that returns a `std::future<nlohmann::json>`.
- `HasPendingRequests` method to check for pending requests, useful for testing.
- New unit tests:
  - **In-order responses**: Verifies that responses are handled in the correct order.
  - **Async method calls**: Tests the functionality of asynchronous method calls.
  - **Multiple async method calls**: Ensures the client can handle multiple concurrent async calls.

## Changed

- Refactored client:
  - `SendMethodCall` now uses `SendMethodCallAsync` internally, blocking until the response is ready.
- Replaced manual string concatenation with `fmt` for cleaner code.