### PR TITLE
Update CCache Key and Restore-Keys in CI Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
         id: ccache
         with:
           path: ~/.cache/ccache
-          key: |
-            ${{ runner.os }}-ccache-${{ hashFiles('conanfile.py') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('CMakePresets.json') }}-${{ github.run_id }}
+          key: ${{ runner.os }}-ccache-${{ hashFiles('conanfile.py') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('CMakePresets.json') }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-ccache-${{ hashFiles('conanfile.py') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('CMakePresets.json') }}
+            ${{ runner.os }}-ccache-${{ hashFiles('conanfile.py') }}-${{ hashFiles('CMakeLists.txt') }}-${{ hashFiles('CMakePresets.json') }}-
+            ${{ runner.os }}-ccache-
 
       - name: Setup Conan
         uses: hankhsu1996/setup-conan@v1


### PR DESCRIPTION
This PR updates the cache key and restore-keys configuration for CCache in the CI workflow:

- **Key**: Changed to a single-line format.
- **Restore-keys**: Added a `-` at the end to broaden cache matching, increasing the chances of finding relevant cache data across runs. Added a fallback `restore-key` for broader matching.

