### PR TITLE
Upgrade Actions-GH-Pages to V4 to Address Node.js Deprecation Warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           path: docs/generated/html
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/generated/html


### PR DESCRIPTION
This PR updates the `peaceiris/actions-gh-pages` action from `v3` to `v4` in the CI workflow.

- **Upgrade Reason**: Resolves the deprecation warning about the action running on a Node.js version that is being deprecated and will be forced to run on Node.js 20.
  
- **Change**: 
  - Updated `peaceiris/actions-gh-pages` from `v3` to `v4`.