### PR TITLE
Standardize Naming Convention Across Project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,49 +1,144 @@
 cmake_minimum_required(VERSION 3.19)
-project(jsonrpc VERSION 1.0.0 LANGUAGES CXX)
+project(jsonrpc-cpp-lib VERSION 1.0.0 LANGUAGES CXX)
 
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-# Set C++ Compiler Launcher
-set(CMAKE_C_COMPILER_LAUNCHER ccache)
-set(CMAKE_CXX_COMPILER_LAUNCHER ccache)
+# Export compile_commands.json for tools like clangd
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Optionally enable ccache if available
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    message(STATUS "Found ccache: ${CCACHE_PROGRAM}")
+    set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
+    set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_PROGRAM})
+else()
+    message(STATUS "ccache not found, proceeding without it.")
+endif()
 
 # Source files
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 
-# Find and link dependencies
-find_package(nlohmann_json REQUIRED)
-find_package(spdlog REQUIRED)
-find_package(bshoshany-thread-pool REQUIRED)
-find_package(asio REQUIRED)
-
-# Add the library target
-add_library(jsonrpc ${SOURCES})
+# Add the library target before linking
+add_library(jsonrpc-cpp-lib ${SOURCES})
 
 # Include directories for the library
-target_include_directories(jsonrpc PUBLIC include)
+target_include_directories(jsonrpc-cpp-lib PUBLIC include)
 
-# Link dependencies
-target_link_libraries(jsonrpc PUBLIC
-    nlohmann_json::nlohmann_json
-    spdlog::spdlog
-    bshoshany-thread-pool::bshoshany-thread-pool
-    asio::asio
-)
+# Check for Conan usage
+if(USE_CONAN)
+    # Find and link dependencies via Conan
+    find_package(nlohmann_json REQUIRED)
+    find_package(spdlog REQUIRED)
+    find_package(bshoshany-thread-pool REQUIRED)
+    find_package(asio REQUIRED)
 
-# Include examples CMake file
-add_subdirectory(examples)
+    # Link dependencies
+    target_link_libraries(jsonrpc-cpp-lib PUBLIC
+        nlohmann_json::nlohmann_json
+        spdlog::spdlog
+        bshoshany-thread-pool::bshoshany-thread-pool
+        asio::asio
+    )
+else()
+    include(FetchContent)
 
-# Ensure compile_commands.json is moved after build
-add_custom_command(
-    TARGET jsonrpc PRE_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_BINARY_DIR}/compile_commands.json
-        ${CMAKE_SOURCE_DIR}/compile_commands.json
-    COMMENT "Copying compile_commands.json to source directory"
-    VERBATIM
-)
+    # Fetch dependencies using FetchContent
+    FetchContent_Declare(
+        nlohmann_json
+        GIT_REPOSITORY https://github.com/nlohmann/json.git
+        GIT_TAG v3.11.3
+    )
+    FetchContent_MakeAvailable(nlohmann_json)
 
-enable_testing()
-add_subdirectory(tests)
+    FetchContent_Declare(
+        spdlog
+        GIT_REPOSITORY https://github.com/gabime/spdlog.git
+        GIT_TAG v1.14.1
+    )
+    FetchContent_MakeAvailable(spdlog)
+
+    FetchContent_Declare(
+        bshoshany_thread_pool
+        GIT_REPOSITORY https://github.com/bshoshany/thread-pool.git
+        GIT_TAG v4.1.0
+    )
+    FetchContent_MakeAvailable(bshoshany_thread_pool)
+
+    # Manually create the bshoshany-thread-pool target
+    add_library(bshoshany-thread-pool INTERFACE)
+    target_include_directories(bshoshany-thread-pool INTERFACE
+        ${bshoshany_thread_pool_SOURCE_DIR}/include
+    )
+
+    FetchContent_Declare(
+        asio
+        GIT_REPOSITORY https://github.com/chriskohlhoff/asio.git
+        GIT_TAG asio-1-28-2
+    )
+    FetchContent_MakeAvailable(asio)
+
+    # Ensure asio include directory is added
+    add_library(asio INTERFACE)
+    target_include_directories(asio INTERFACE
+        ${asio_SOURCE_DIR}/asio/include
+    )
+
+    # Link dependencies
+    target_link_libraries(jsonrpc-cpp-lib PUBLIC
+        nlohmann_json::nlohmann_json
+        spdlog::spdlog
+        bshoshany-thread-pool
+        asio
+    )
+endif()
+
+# Option to build examples
+option(BUILD_EXAMPLES "Build examples" ON)
+if(BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()
+
+# Conditionally copy compile_commands.json if it exists
+if(EXISTS ${CMAKE_BINARY_DIR}/compile_commands.json)
+    add_custom_command(
+        TARGET jsonrpc-cpp-lib PRE_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${CMAKE_BINARY_DIR}/compile_commands.json
+            ${CMAKE_SOURCE_DIR}/compile_commands.json
+        COMMENT "Copying compile_commands.json to source directory"
+        VERBATIM
+    )
+endif()
+
+# Option to build tests
+option(BUILD_TESTS "Build tests" OFF)
+
+# Set BUILD_TESTS to ON if this is the main project
+if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+    set(BUILD_TESTS ON)
+endif()
+
+# Include tests only if requested and if the tests directory exists
+if(BUILD_TESTS AND EXISTS "${CMAKE_SOURCE_DIR}/tests")
+    enable_testing()
+
+    # Conditional Catch2 handling for testing
+    if(USE_CONAN)
+        find_package(Catch2 REQUIRED)
+    else()
+        FetchContent_Declare(
+            Catch2
+            GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+            GIT_TAG v3.6.0
+        )
+        FetchContent_MakeAvailable(Catch2)
+
+        # Update CMAKE_MODULE_PATH to include Catch2 extras
+        list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
+    endif()
+
+    add_subdirectory(tests)
+endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -6,19 +6,13 @@
       "name": "release",
       "displayName": "Release Config",
       "description": "Release configuration preset inheriting from conan-release.",
-      "inherits": "conan-release",
-      "cacheVariables": {
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
-      }
+      "inherits": "conan-release"
     },
     {
       "name": "debug",
       "displayName": "Debug Config",
       "description": "Debug configuration preset inheriting from conan-debug.",
-      "inherits": "conan-debug",
-      "cacheVariables": {
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
-      }
+      "inherits": "conan-debug"
     }
   ],
   "buildPresets": [

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,7 +3,7 @@ MODULE.bazel file for the jsonrpc module
 """
 
 module(
-    name = "jsonrpc",
+    name = "jsonrpc_cpp_lib",
     version = "1.0.0",
 )
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # JSON-RPC 2.0 Modern C++ Library
 
-[![CI](https://github.com/hankhsu1996/json-rpc-cpp-lib/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/hankhsu1996/json-rpc-cpp-lib/actions/workflows/ci.yml)
-![GitHub Release](https://img.shields.io/github/v/release/hankhsu1996/json-rpc-cpp-lib)
-![GitHub License](https://img.shields.io/github/license/hankhsu1996/json-rpc-cpp-lib)
+[![CI](https://github.com/hankhsu1996/jsonrpc-cpp-lib/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/hankhsu1996/jsonrpc-cpp-lib/actions/workflows/ci.yml)
+![GitHub Release](https://img.shields.io/github/v/release/hankhsu1996/jsonrpc-cpp-lib)
+![GitHub License](https://img.shields.io/github/license/hankhsu1996/jsonrpc-cpp-lib)
 
 Welcome to the **JSON-RPC 2.0 Modern C++ Library**! This library provides a lightweight, modern C++ implementation of [JSON-RPC 2.0](https://www.jsonrpc.org/specification) servers and clients. It is designed to be flexible, allowing integration with various transport layers. This library makes it easy to register methods and notifications, binding them to client logic efficiently.
 
@@ -28,7 +28,27 @@ Welcome to the **JSON-RPC 2.0 Modern C++ Library**! This library provides a ligh
 To include this library in your project with Bazel, ensure you are using Bazel 7.0 or later, as Bzlmod is enabled by default. Add the following to your `MODULE.bazel` file:
 
 ```bazel
-bazel_dep(name = "jsonrpc", version = "1.0.0")
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+  name = "jsonrpc",
+  urls = ["https://github.com/hankhsu1996/jsonrpc-cpp-lib/archive/refs/tags/v1.0.0.tar.gz"],
+  strip_prefix = "jsonrpc-cpp-lib-1.0.0",
+  sha256 = "8b66af17b46af422a169aafbe046a65632e0667a9fab02a1b85b3af1bc3d8862",
+)
+```
+
+### Optional: Using Conan 2
+
+For projects using Conan, create a `conanfile.txt` in your project directory with the following content:
+
+```ini
+[requires]
+jsonrpc-cpp-lib/1.0.0
+
+[generators]
+CMakeDeps
+CMakeToolchain
+
 ```
 
 ### Optional: Using CMake FetchContent
@@ -39,24 +59,10 @@ If you prefer using CMake, add the library to your project with the following in
 include(FetchContent)
 FetchContent_Declare(
   jsonrpc
-  GIT_REPOSITORY https://github.com/hankhsu1996/json-rpc-cpp-lib.git
-  GIT_TAG main
+  GIT_REPOSITORY https://github.com/hankhsu1996/jsonrpc-cpp-lib.git
+  GIT_TAG v1.0.0
 )
 FetchContent_MakeAvailable(jsonrpc)
-```
-
-### Optional: Using Conan 2
-
-For projects using Conan, create a `conanfile.txt` in your project directory with the following content:
-
-```ini
-[requires]
-json-rpc-cpp-lib/1.0.0
-
-[generators]
-CMakeDeps
-CMakeToolchain
-
 ```
 
 ## 📖 Usage and Examples
@@ -162,6 +168,16 @@ For Debug configuration:
 cmake --preset debug
 cmake --build --preset debug
 ctest --preset debug
+```
+
+### Optional: CMake without Conan
+
+If you prefer not to use Conan, you can build the project with CMake directly:
+
+```
+cmake -S . -B build
+cmake --build build
+ctest --test-dir build
 ```
 
 ### Compilation Database

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ http_archive(
   name = "jsonrpc",
   urls = ["https://github.com/hankhsu1996/jsonrpc-cpp-lib/archive/refs/tags/v1.0.0.tar.gz"],
   strip_prefix = "jsonrpc-cpp-lib-1.0.0",
-  sha256 = "8b66af17b46af422a169aafbe046a65632e0667a9fab02a1b85b3af1bc3d8862",
+  sha256 = "a381dc02ab95c31902077793e926adbb0d8f67eadbc386b03451e952d50f0615",
 )
 ```
 
@@ -48,7 +48,6 @@ jsonrpc-cpp-lib/1.0.0
 [generators]
 CMakeDeps
 CMakeToolchain
-
 ```
 
 ### Optional: Using CMake FetchContent
@@ -58,11 +57,11 @@ If you prefer using CMake, add the library to your project with the following in
 ```cmake
 include(FetchContent)
 FetchContent_Declare(
-  jsonrpc
+  jsonrpc-cpp-lib
   GIT_REPOSITORY https://github.com/hankhsu1996/jsonrpc-cpp-lib.git
   GIT_TAG v1.0.0
 )
-FetchContent_MakeAvailable(jsonrpc)
+FetchContent_MakeAvailable(jsonrpc-cpp-lib)
 ```
 
 ## 📖 Usage and Examples

--- a/conanfile.py
+++ b/conanfile.py
@@ -2,12 +2,13 @@ from conan import ConanFile
 from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
 
 
-class JsonRpcConan(ConanFile):
-    name = "json-rpc-2.0"
+class JsonRpcRecipe(ConanFile):
+    """ Conan recipe for jsonrpc-cpp-lib """
+    name = "jsonrpc-cpp-lib"
     version = "1.0.0"
     license = "MIT"
     author = "Shou-Li Hsu <hank850503@gmail.com>"
-    url = "https://github.com/hankhsu1996/json-rpc-2.0"
+    url = "https://github.com/hankhsu1996/jsonrpc-cpp-lib"
     description = (
         "Welcome to the JSON-RPC 2.0 Modern C++ Library! "
         "This library provides a lightweight, modern C++ implementation of "
@@ -37,26 +38,45 @@ class JsonRpcConan(ConanFile):
         "catch2/3.6.0"
     ]
 
-    # Sources are located in the same place as this recipe, copy them to the recipe
-    exports_sources = "CMakeLists.txt", "src/*", "include/*"
+    # Define options for building examples and tests
+    options = {
+        "build_examples": [True, False],
+        "build_tests": [True, False]
+    }
+    default_options = {
+        "build_examples": False,
+        "build_tests": False
+    }
+
+    exports_sources = "CMakeLists.txt", "src/*", "include/*", "LICENSE", "README.md"
 
     def layout(self):
+        """ Define the layout of the project """
         cmake_layout(self)
 
     def generate(self):
+        """ Generate the CMake toolchain and dependencies files """
         deps = CMakeDeps(self)
         deps.generate()
         tc = CMakeToolchain(self)
         tc.user_presets_path = 'ConanPresets.json'
-
+        tc.cache_variables["USE_CONAN"] = "ON"
+        tc.cache_variables["BUILD_EXAMPLES"] = self.options.build_examples
+        tc.cache_variables["BUILD_TESTS"] = self.options.build_tests
         tc.generator = "Ninja"
         tc.generate()
 
     def build(self):
+        """ Build the project """
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
 
     def package(self):
+        """ Package the project """
         cmake = CMake(self)
         cmake.install()
+
+    def package_info(self):
+        """ Define package information for consumers """
+        self.cpp_info.libs = ["jsonrpc-cpp-lib"]

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,43 +2,43 @@
 
 # Calculator example using Standard I/O transport
 add_executable(stdio_client calculator_example/stdio/client.cpp)
-target_link_libraries(stdio_client PRIVATE jsonrpc)
+target_link_libraries(stdio_client PRIVATE jsonrpc-cpp-lib)
 
 add_executable(stdio_server calculator_example/stdio/server.cpp)
-target_link_libraries(stdio_server PRIVATE jsonrpc)
+target_link_libraries(stdio_server PRIVATE jsonrpc-cpp-lib)
 
 # Calculator example using Unix domain socket (pipe) transport
 add_executable(pipe_client calculator_example/pipe/client.cpp)
-target_link_libraries(pipe_client PRIVATE jsonrpc)
+target_link_libraries(pipe_client PRIVATE jsonrpc-cpp-lib)
 
 add_executable(pipe_server calculator_example/pipe/server.cpp)
-target_link_libraries(pipe_server PRIVATE jsonrpc)
+target_link_libraries(pipe_server PRIVATE jsonrpc-cpp-lib)
 
 # Calculator example using Framed Unix domain socket transport
 add_executable(framed_pipe_client calculator_example/framed_pipe/client.cpp)
-target_link_libraries(framed_pipe_client PRIVATE jsonrpc)
+target_link_libraries(framed_pipe_client PRIVATE jsonrpc-cpp-lib)
 
 add_executable(framed_pipe_server calculator_example/framed_pipe/server.cpp)
-target_link_libraries(framed_pipe_server PRIVATE jsonrpc)
+target_link_libraries(framed_pipe_server PRIVATE jsonrpc-cpp-lib)
 
 # Calculator example using ASIO socket transport
 add_executable(socket_client calculator_example/socket/client.cpp)
-target_link_libraries(socket_client PRIVATE jsonrpc)
+target_link_libraries(socket_client PRIVATE jsonrpc-cpp-lib)
 
 add_executable(socket_server calculator_example/socket/server.cpp)
-target_link_libraries(socket_server PRIVATE jsonrpc)
+target_link_libraries(socket_server PRIVATE jsonrpc-cpp-lib)
 
 # Calculator example using Framed ASIO socket transport
 add_executable(framed_socket_client calculator_example/framed_socket/client.cpp)
-target_link_libraries(framed_socket_client PRIVATE jsonrpc)
+target_link_libraries(framed_socket_client PRIVATE jsonrpc-cpp-lib)
 
 add_executable(framed_socket_server calculator_example/framed_socket/server.cpp)
-target_link_libraries(framed_socket_server PRIVATE jsonrpc)
+target_link_libraries(framed_socket_server PRIVATE jsonrpc-cpp-lib)
 
 # LSP example using Unix domain socket (pipe) transport
 add_executable(pipe_lsp_server lsp_example/pipe/lsp_server.cpp)
-target_link_libraries(pipe_lsp_server PRIVATE jsonrpc)
+target_link_libraries(pipe_lsp_server PRIVATE jsonrpc-cpp-lib)
 
 # LSP example using ASIO socket transport
 add_executable(socket_lsp_server lsp_example/socket/lsp_server.cpp)
-target_link_libraries(socket_lsp_server PRIVATE jsonrpc)
+target_link_libraries(socket_lsp_server PRIVATE jsonrpc-cpp-lib)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,10 +1,3 @@
-# Add Catch2
-find_package(Catch2 3.6.0 REQUIRED)
-
-# Update CMAKE_MODULE_PATH to include Catch2 extras
-list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
-include(Catch)
-
 # Add test files
 file(GLOB_RECURSE TEST_SOURCES "*.cpp")
 
@@ -12,7 +5,8 @@ file(GLOB_RECURSE TEST_SOURCES "*.cpp")
 add_executable(tests ${TEST_SOURCES})
 
 # Link with the main project and Catch2
-target_link_libraries(tests PRIVATE jsonrpc Catch2::Catch2WithMain)
+target_link_libraries(tests PRIVATE jsonrpc-cpp-lib Catch2::Catch2WithMain)
 
 # Register the tests
+include(Catch)
 catch_discover_tests(tests)


### PR DESCRIPTION
This PR standardizes the naming convention across all tools and files in the project to ensure consistency. Changes include:

- Updated CMake project name to `jsonrpc-cpp-lib`.
- Changed Bazel module name to `jsonrpc_cpp_lib`.
- Renamed Conan package to `jsonrpc-cpp-lib`.
- Modified repository references to match the standardized name.
- Adjusted example and test files to link with `jsonrpc-cpp-lib`.

These changes improve clarity and maintain a consistent naming convention across the project.
