### PR TITLE
Add server-to-client notification support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,9 +1,5 @@
 # .bazelrc
 
-# Enable ccache
-build --sandbox_writable_path=$HOME/.cache/ccache
-build --experimental_guard_against_concurrent_changes
-
 # C++ toolchain configuration
 build --cxxopt='-std=c++20'
 build --host_cxxopt='-std=c++20'

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,6 @@
 # .bazelrc
 
-# C++ toolchain configuration
+# Common settings for all builds
 build --cxxopt='-std=c++20'
 build --host_cxxopt='-std=c++20'
 
@@ -19,5 +19,5 @@ build:release --compilation_mode=opt
 build:release --copt='-O3'
 build:release --strip=always
 
-# Default to release mode
-build --config=release
+# Default to release if no config specified
+build:default --config=release

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,7 @@
 # .bazelrc
 
 # Enable ccache
-build --sandbox_writable_path=/home/hankhsu/.cache/ccache
+build --sandbox_writable_path=$HOME/.cache/ccache
 build --experimental_guard_against_concurrent_changes
 
 # C++ toolchain configuration
@@ -11,3 +11,17 @@ build --host_cxxopt='-std=c++20'
 # Enable warnings
 build --cxxopt='-Wall'
 build --cxxopt='-Wextra'
+build --cxxopt='-Wpedantic'
+build --cxxopt='-Werror'
+
+# Build configurations
+build:debug --compilation_mode=dbg
+build:debug --cxxopt='-g'
+build:debug --strip=never
+
+build:release --compilation_mode=opt
+build:release --copt='-O3'
+build:release --strip=always
+
+# Default to release mode
+build --config=release

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,12 @@
 # .bazelrc
 
-# Set the C++ standard to C++20
+# Enable ccache
+build --sandbox_writable_path=/home/hankhsu/.cache/ccache
+build --experimental_guard_against_concurrent_changes
+
+# C++ toolchain configuration
 build --cxxopt='-std=c++20'
+build --host_cxxopt='-std=c++20'
 
 # Enable warnings
 build --cxxopt='-Wall'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,13 +66,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          key: ${{ runner.os }}-ccache-bazel-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-ccache-bazel-
-
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.8.5
         with:
@@ -82,10 +75,9 @@ jobs:
 
       - name: Build with Bazel
         run: |
-          mkdir -p $HOME/.cache/ccache
-          # Build and test release configuration
+          # Build release configuration
           bazel build //...
-          # Build and test debug configuration
+          # Build debug configuration
           bazel build //... --config=debug
 
       - name: Test with Bazel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ runner.os }}-ccache-bazel-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-bazel-
+
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.8.5
         with:
@@ -75,11 +82,18 @@ jobs:
 
       - name: Build with Bazel
         run: |
+          mkdir -p $HOME/.cache/ccache
+          # Build and test release configuration
           bazel build //...
+          # Build and test debug configuration
+          bazel build //... --config=debug
 
       - name: Test with Bazel
         run: |
+          # Test release configuration
           bazel test //...
+          # Test debug configuration
+          bazel test //... --config=debug
 
   docs:
     runs-on: ubuntu-latest

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ module(
 )
 
 # Dependencies from the Bazel Central Registry
-bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "rules_cc", version = "0.0.17")
 bazel_dep(name = "nlohmann_json", version = "3.11.3")
 bazel_dep(name = "spdlog", version = "1.14.1")
 bazel_dep(name = "asio", version = "1.28.2")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,369 +1,246 @@
 {
-  "lockFileVersion": 11,
+  "lockFileVersion": 18,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
     "https://bcr.bazel.build/modules/abseil-cpp/20211102.0/MODULE.bazel": "70390338f7a5106231d20620712f7cccb659cd0e9d073d1991c038eb9fc57589",
-    "https://bcr.bazel.build/modules/abseil-cpp/20211102.0/source.json": "7e3a9adf473e9af076ae485ed649d5641ad50ec5c11718103f34de03170d94ad",
-    "https://bcr.bazel.build/modules/apple_support/1.5.0/MODULE.bazel": "50341a62efbc483e8a2a6aec30994a58749bd7b885e18dd96aa8c33031e558ef",
-    "https://bcr.bazel.build/modules/apple_support/1.5.0/source.json": "eb98a7627c0bc486b57f598ad8da50f6625d974c8f723e9ea71bd39f709c9862",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230125.1/MODULE.bazel": "89047429cb0207707b2dface14ba7f8df85273d484c2572755be4bab7ce9c3a0",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.0.bcr.1/MODULE.bazel": "1c8cec495288dccd14fdae6e3f95f772c1c91857047a098fad772034264cc8cb",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.0/MODULE.bazel": "d253ae36a8bd9ee3c5955384096ccb6baf16a1b1e93e858370da0a3b94f77c16",
+    "https://bcr.bazel.build/modules/abseil-cpp/20230802.1/MODULE.bazel": "fa92e2eb41a04df73cdabeec37107316f7e5272650f81d6cc096418fe647b915",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/MODULE.bazel": "37bcdb4440fbb61df6a1c296ae01b327f19e9bb521f9b8e26ec854b6f97309ed",
+    "https://bcr.bazel.build/modules/abseil-cpp/20240116.1/source.json": "9be551b8d4e3ef76875c0d744b5d6a504a27e3ae67bc6b28f46415fd2d2957da",
     "https://bcr.bazel.build/modules/asio/1.28.2/MODULE.bazel": "c985926a85680be7047309db9fb56f2e1c590394adbe48f309ee76d4c78ab8ce",
     "https://bcr.bazel.build/modules/asio/1.28.2/source.json": "10d8d6af06420092fa73c6e7e79e36dee3c166c1e668ab2edefd4c497c37bbcf",
+    "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
-    "https://bcr.bazel.build/modules/bazel_features/1.11.0/source.json": "c9320aa53cd1c441d24bd6b716da087ad7e4ff0d9742a9884587596edfe53015",
+    "https://bcr.bazel.build/modules/bazel_features/1.15.0/MODULE.bazel": "d38ff6e517149dc509406aca0db3ad1efdd890a85e049585b7234d04238e2a4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.17.0/MODULE.bazel": "039de32d21b816b47bd42c778e0454217e9c9caac4a3cf8e15c7231ee3ddee4d",
+    "https://bcr.bazel.build/modules/bazel_features/1.18.0/MODULE.bazel": "1be0ae2557ab3a72a57aeb31b29be347bcdc5d2b1eb1e70f39e3851a7e97041a",
+    "https://bcr.bazel.build/modules/bazel_features/1.19.0/MODULE.bazel": "59adcdf28230d220f0067b1f435b8537dd033bfff8db21335ef9217919c7fb58",
+    "https://bcr.bazel.build/modules/bazel_features/1.21.0/MODULE.bazel": "675642261665d8eea09989aa3b8afb5c37627f1be178382c320d1b46afba5e3b",
+    "https://bcr.bazel.build/modules/bazel_features/1.21.0/source.json": "3e8379efaaef53ce35b7b8ba419df829315a880cb0a030e5bb45c96d6d5ecb5f",
+    "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
+    "https://bcr.bazel.build/modules/bazel_features/1.9.1/MODULE.bazel": "8f679097876a9b609ad1f60249c49d68bfab783dd9be012faf9d82547b14815a",
     "https://bcr.bazel.build/modules/bazel_skylib/1.0.3/MODULE.bazel": "bcb0fd896384802d1ad283b4e4eb4d718eebd8cb820b0a2c3a347fb971afd9d8",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.1.1/MODULE.bazel": "1add3e7d93ff2e6998f9e118022c84d163917d912f5afafb3058e3d2f1545b5e",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.2.0/MODULE.bazel": "44fe84260e454ed94ad326352a698422dbe372b21a1ac9f3eab76eb531223686",
     "https://bcr.bazel.build/modules/bazel_skylib/1.2.1/MODULE.bazel": "f35baf9da0efe45fa3da1696ae906eea3d615ad41e2e3def4aeb4e8bc0ef9a7a",
     "https://bcr.bazel.build/modules/bazel_skylib/1.3.0/MODULE.bazel": "20228b92868bf5cfc41bda7afc8a8ba2a543201851de39d990ec957b513579c5",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.4.1/MODULE.bazel": "a0dcb779424be33100dcae821e9e27e4f2901d9dfd5333efe5ac6a8d7ab75e1d",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.4.2/MODULE.bazel": "3bd40978e7a1fac911d5989e6b09d8f64921865a45822d8b09e815eaa726a651",
     "https://bcr.bazel.build/modules/bazel_skylib/1.5.0/MODULE.bazel": "32880f5e2945ce6a03d1fbd588e9198c0a959bb42297b2cfaf1685b7bc32e138",
     "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/MODULE.bazel": "8fdee2dbaace6c252131c00e1de4b165dc65af02ea278476187765e1a617b917",
-    "https://bcr.bazel.build/modules/bazel_skylib/1.6.1/source.json": "082ed5f9837901fada8c68c2f3ddc958bb22b6d654f71dd73f3df30d45d4b749",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.0/MODULE.bazel": "0db596f4563de7938de764cc8deeabec291f55e8ec15299718b93c4423e9796d",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/MODULE.bazel": "3120d80c5861aa616222ec015332e5f8d3171e062e3e804a2a0253e1be26e59b",
+    "https://bcr.bazel.build/modules/bazel_skylib/1.7.1/source.json": "f121b43eeefc7c29efbd51b83d08631e2347297c95aac9764a701f2a6a2bb953",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/MODULE.bazel": "2e8dd40ede9c454042645fd8d8d0cd1527966aa5c919de86661e62953cd73d84",
     "https://bcr.bazel.build/modules/buildozer/7.1.2/source.json": "c9028a501d2db85793a6996205c8de120944f50a0d570438fcae0457a5f9d1f8",
     "https://bcr.bazel.build/modules/catch2/3.6.0/MODULE.bazel": "6a1536f01f4c7ede6f842099f53e7c27e17d43e0012ae195521d3572d1e00a0e",
     "https://bcr.bazel.build/modules/catch2/3.6.0/source.json": "c774717702675ab43bc1d1b59a14814c89916fc1d8ec3357fb3dbc672655fb1c",
     "https://bcr.bazel.build/modules/fmt/10.2.1.bcr.1/MODULE.bazel": "ab0513a81ae5bf2606b47da41662afdad0ffec0641106fa524ff77d421b28531",
     "https://bcr.bazel.build/modules/fmt/10.2.1.bcr.1/source.json": "4ce5c5596455e75a485af3f1f906117324a4f18b6b999f88df6786f3b355553d",
+    "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
-    "https://bcr.bazel.build/modules/googletest/1.11.0/source.json": "c73d9ef4268c91bd0c1cd88f1f9dfa08e814b1dbe89b5f594a9f08ba0244d206",
+    "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
+    "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/source.json": "41e9e129f80d8c8bf103a7acc337b76e54fad1214ac0a7084bf24f4cd924b8b4",
+    "https://bcr.bazel.build/modules/googletest/1.14.0/MODULE.bazel": "cfbcbf3e6eac06ef9d85900f64424708cc08687d1b527f0ef65aa7517af8118f",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/MODULE.bazel": "31271aedc59e815656f5736f282bb7509a97c7ecb43e927ac1a37966e0578075",
+    "https://bcr.bazel.build/modules/jsoncpp/1.9.5/source.json": "4108ee5085dd2885a341c7fab149429db457b3169b86eb081fa245eadf69169d",
+    "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
     "https://bcr.bazel.build/modules/nlohmann_json/3.11.3/MODULE.bazel": "87023db2f55fc3a9949c7b08dc711fae4d4be339a80a99d04453c4bb3998eefc",
     "https://bcr.bazel.build/modules/nlohmann_json/3.11.3/source.json": "296c63a90c6813e53b3812d24245711981fc7e563d98fe15625f55181494488a",
+    "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
+    "https://bcr.bazel.build/modules/platforms/0.0.10/source.json": "f22828ff4cf021a6b577f1bf6341cb9dcd7965092a439f64fc1bb3b7a5ae4bd5",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
     "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
     "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
     "https://bcr.bazel.build/modules/platforms/0.0.7/MODULE.bazel": "72fd4a0ede9ee5c021f6a8dd92b503e089f46c227ba2813ff183b71616034814",
-    "https://bcr.bazel.build/modules/platforms/0.0.9/MODULE.bazel": "4a87a60c927b56ddd67db50c89acaa62f4ce2a1d2149ccb63ffd871d5ce29ebc",
-    "https://bcr.bazel.build/modules/platforms/0.0.9/source.json": "cd74d854bf16a9e002fb2ca7b1a421f4403cda29f824a765acd3a8c56f8d43e6",
+    "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
-    "https://bcr.bazel.build/modules/protobuf/21.7/source.json": "bbe500720421e582ff2d18b0802464205138c06056f443184de39fbb8187b09b",
+    "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
+    "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
+    "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
+    "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
+    "https://bcr.bazel.build/modules/protobuf/29.0/source.json": "b857f93c796750eef95f0d61ee378f3420d00ee1dd38627b27193aa482f4f981",
     "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
-    "https://bcr.bazel.build/modules/protobuf/3.19.6/MODULE.bazel": "9233edc5e1f2ee276a60de3eaa47ac4132302ef9643238f23128fea53ea12858",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/MODULE.bazel": "88af1c246226d87e65be78ed49ecd1e6f5e98648558c14ce99176da041dc378e",
+    "https://bcr.bazel.build/modules/pybind11_bazel/2.11.1/source.json": "be4789e951dd5301282729fe3d4938995dc4c1a81c2ff150afc9f1b0504c6022",
+    "https://bcr.bazel.build/modules/re2/2023-09-01/MODULE.bazel": "cb3d511531b16cfc78a225a9e2136007a48cf8a677e4264baeab57fe78a80206",
+    "https://bcr.bazel.build/modules/re2/2023-09-01/source.json": "e044ce89c2883cd957a2969a43e79f7752f9656f6b20050b62f90ede21ec6eb4",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/MODULE.bazel": "48809ab0091b07ad0182defb787c4c5328bd3a278938415c00a7b69b50c4d3a8",
+    "https://bcr.bazel.build/modules/rules_android/0.1.1/source.json": "e6986b41626ee10bdc864937ffb6d6bf275bb5b9c65120e6137d56e6331f089e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.1/MODULE.bazel": "cb2aa0747f84c6c3a78dad4e2049c154f08ab9d166b1273835a8174940365647",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.10/MODULE.bazel": "ec1705118f7eaedd6e118508d3d26deba2a4e76476ada7e0e3965211be012002",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.13/MODULE.bazel": "0e8529ed7b323dad0775ff924d2ae5af7640b23553dfcd4d34344c7e7a867191",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.14/MODULE.bazel": "5e343a3aac88b8d7af3b1b6d2093b55c347b8eefc2e7d1442f7a02dc8fea48ac",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.15/MODULE.bazel": "6704c35f7b4a72502ee81f61bf88706b54f06b3cbe5558ac17e2e14666cd5dcc",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.16/MODULE.bazel": "7661303b8fc1b4d7f532e54e9d6565771fea666fbdf839e0a86affcd02defe87",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.17/MODULE.bazel": "2ae1d8f4238ec67d7185d8861cb0a2cdf4bc608697c331b95bf990e69b62e64a",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.17/source.json": "4db99b3f55c90ab28d14552aa0632533e3e8e5e9aea0f5c24ac0014282c2a7c5",
     "https://bcr.bazel.build/modules/rules_cc/0.0.2/MODULE.bazel": "6915987c90970493ab97393024c156ea8fb9f3bea953b2f3ec05c34f19b5695c",
+    "https://bcr.bazel.build/modules/rules_cc/0.0.6/MODULE.bazel": "abf360251023dfe3efcef65ab9d56beefa8394d4176dd29529750e1c57eaa33f",
     "https://bcr.bazel.build/modules/rules_cc/0.0.8/MODULE.bazel": "964c85c82cfeb6f3855e6a07054fdb159aced38e99a5eecf7bce9d53990afa3e",
     "https://bcr.bazel.build/modules/rules_cc/0.0.9/MODULE.bazel": "836e76439f354b89afe6a911a7adf59a6b2518fafb174483ad78a2a2fde7b1c5",
-    "https://bcr.bazel.build/modules/rules_cc/0.0.9/source.json": "1f1ba6fea244b616de4a554a0f4983c91a9301640c8fe0dd1d410254115c8430",
+    "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
+    "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/source.json": "c8b1e2c717646f1702290959a3302a178fb639d987ab61d548105019f11e527e",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
+    "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
+    "https://bcr.bazel.build/modules/rules_java/6.0.0/MODULE.bazel": "8a43b7df601a7ec1af61d79345c17b31ea1fedc6711fd4abfd013ea612978e39",
+    "https://bcr.bazel.build/modules/rules_java/6.4.0/MODULE.bazel": "e986a9fe25aeaa84ac17ca093ef13a4637f6107375f64667a15999f77db6c8f6",
+    "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
+    "https://bcr.bazel.build/modules/rules_java/7.10.0/MODULE.bazel": "530c3beb3067e870561739f1144329a21c851ff771cd752a49e06e3dc9c2e71a",
+    "https://bcr.bazel.build/modules/rules_java/7.12.2/MODULE.bazel": "579c505165ee757a4280ef83cda0150eea193eed3bef50b1004ba88b99da6de6",
+    "https://bcr.bazel.build/modules/rules_java/7.2.0/MODULE.bazel": "06c0334c9be61e6cef2c8c84a7800cef502063269a5af25ceb100b192453d4ab",
+    "https://bcr.bazel.build/modules/rules_java/7.3.2/MODULE.bazel": "50dece891cfdf1741ea230d001aa9c14398062f2b7c066470accace78e412bc2",
     "https://bcr.bazel.build/modules/rules_java/7.6.1/MODULE.bazel": "2f14b7e8a1aa2f67ae92bc69d1ec0fa8d9f827c4e17ff5e5f02e91caa3b2d0fe",
-    "https://bcr.bazel.build/modules/rules_java/7.6.1/source.json": "8f3f3076554e1558e8e468b2232991c510ecbcbed9e6f8c06ac31c93bcf38362",
+    "https://bcr.bazel.build/modules/rules_java/8.6.1/MODULE.bazel": "f4808e2ab5b0197f094cabce9f4b006a27766beb6a9975931da07099560ca9c2",
+    "https://bcr.bazel.build/modules/rules_java/8.6.1/source.json": "f18d9ad3c4c54945bf422ad584fa6c5ca5b3116ff55a5b1bc77e5c1210be5960",
     "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/MODULE.bazel": "a56b85e418c83eb1839819f0b515c431010160383306d13ec21959ac412d2fe7",
-    "https://bcr.bazel.build/modules/rules_jvm_external/4.4.2/source.json": "a075731e1b46bc8425098512d038d416e966ab19684a10a34f4741295642fc35",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.1/MODULE.bazel": "33f6f999e03183f7d088c9be518a63467dfd0be94a11d0055fe2d210f89aa909",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.2/MODULE.bazel": "d9351ba35217ad0de03816ef3ed63f89d411349353077348a45348b096615036",
+    "https://bcr.bazel.build/modules/rules_jvm_external/5.3/MODULE.bazel": "bf93870767689637164657731849fb887ad086739bd5d360d90007a581d5527d",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.1/MODULE.bazel": "75b5fec090dbd46cf9b7d8ea08cf84a0472d92ba3585b476f44c326eda8059c4",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/MODULE.bazel": "c998e060b85f71e00de5ec552019347c8bca255062c990ac02d051bb80a38df0",
+    "https://bcr.bazel.build/modules/rules_jvm_external/6.3/source.json": "6f5f5a5a4419ae4e37c35a5bb0a6ae657ed40b7abc5a5189111b47fcebe43197",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.0/MODULE.bazel": "ef85697305025e5a61f395d4eaede272a5393cee479ace6686dba707de804d59",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/MODULE.bazel": "d269a01a18ee74d0335450b10f62c9ed81f2321d7958a2934e44272fe82dcef3",
+    "https://bcr.bazel.build/modules/rules_kotlin/1.9.6/source.json": "2faa4794364282db7c06600b7e5e34867a564ae91bda7cae7c29c64e9466b7d5",
     "https://bcr.bazel.build/modules/rules_license/0.0.3/MODULE.bazel": "627e9ab0247f7d1e05736b59dbb1b6871373de5ad31c3011880b4133cafd4bd0",
     "https://bcr.bazel.build/modules/rules_license/0.0.7/MODULE.bazel": "088fbeb0b6a419005b89cf93fe62d9517c0a2b8bb56af3244af65ecfe37e7d5d",
-    "https://bcr.bazel.build/modules/rules_license/0.0.7/source.json": "355cc5737a0f294e560d52b1b7a6492d4fff2caf0bef1a315df5a298fca2d34a",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/MODULE.bazel": "a7fda60eefdf3d8c827262ba499957e4df06f659330bbe6cdbdb975b768bb65c",
+    "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
     "https://bcr.bazel.build/modules/rules_pkg/0.7.0/MODULE.bazel": "df99f03fc7934a4737122518bb87e667e62d780b610910f0447665a7e2be62dc",
-    "https://bcr.bazel.build/modules/rules_pkg/0.7.0/source.json": "c2557066e0c0342223ba592510ad3d812d4963b9024831f7f66fd0584dd8c66c",
+    "https://bcr.bazel.build/modules/rules_pkg/1.0.1/MODULE.bazel": "5b1df97dbc29623bccdf2b0dcd0f5cb08e2f2c9050aab1092fd39a41e82686ff",
+    "https://bcr.bazel.build/modules/rules_pkg/1.0.1/source.json": "bd82e5d7b9ce2d31e380dd9f50c111d678c3bdaca190cb76b0e1c71b05e1ba8a",
     "https://bcr.bazel.build/modules/rules_proto/4.0.0/MODULE.bazel": "a7a7b6ce9bee418c1a760b3d84f83a299ad6952f9903c67f19e4edd964894e06",
     "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
-    "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/source.json": "d57902c052424dfda0e71646cb12668d39c4620ee0544294d9d941e7d12bc3a9",
+    "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
+    "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
+    "https://bcr.bazel.build/modules/rules_proto/7.0.2/source.json": "1e5e7260ae32ef4f2b52fd1d0de8d03b606a44c91b694d2f1afb1d3b28a48ce1",
     "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
-    "https://bcr.bazel.build/modules/rules_python/0.22.1/MODULE.bazel": "26114f0c0b5e93018c0c066d6673f1a2c3737c7e90af95eff30cfee38d0bbac7",
-    "https://bcr.bazel.build/modules/rules_python/0.22.1/source.json": "57226905e783bae7c37c2dd662be078728e48fa28ee4324a7eabcafb5a43d014",
+    "https://bcr.bazel.build/modules/rules_python/0.23.1/MODULE.bazel": "49ffccf0511cb8414de28321f5fcf2a31312b47c40cc21577144b7447f2bf300",
+    "https://bcr.bazel.build/modules/rules_python/0.25.0/MODULE.bazel": "72f1506841c920a1afec76975b35312410eea3aa7b63267436bfb1dd91d2d382",
+    "https://bcr.bazel.build/modules/rules_python/0.28.0/MODULE.bazel": "cba2573d870babc976664a912539b320cbaa7114cd3e8f053c720171cde331ed",
+    "https://bcr.bazel.build/modules/rules_python/0.31.0/MODULE.bazel": "93a43dc47ee570e6ec9f5779b2e64c1476a6ce921c48cc9a1678a91dd5f8fd58",
     "https://bcr.bazel.build/modules/rules_python/0.4.0/MODULE.bazel": "9208ee05fd48bf09ac60ed269791cf17fb343db56c8226a720fbb1cdf467166c",
+    "https://bcr.bazel.build/modules/rules_python/0.40.0/MODULE.bazel": "9d1a3cd88ed7d8e39583d9ffe56ae8a244f67783ae89b60caafc9f5cf318ada7",
+    "https://bcr.bazel.build/modules/rules_python/0.40.0/source.json": "939d4bd2e3110f27bfb360292986bb79fd8dcefb874358ccd6cdaa7bda029320",
+    "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
+    "https://bcr.bazel.build/modules/rules_shell/0.2.0/source.json": "7f27af3c28037d9701487c4744b5448d26537cc66cdef0d8df7ae85411f8de95",
     "https://bcr.bazel.build/modules/spdlog/1.14.1/MODULE.bazel": "52e4b8dbfac282ce6123ecff8b374ff38e595a583ddb7d0af331eae7993faf40",
     "https://bcr.bazel.build/modules/spdlog/1.14.1/source.json": "f26b37601d2bfd5be755626965cbc07fcd4c0e9ab1657bf17fbb2f738693c752",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
-    "https://bcr.bazel.build/modules/stardoc/0.5.1/source.json": "a96f95e02123320aa015b956f29c00cb818fa891ef823d55148e1a362caacf29",
+    "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
+    "https://bcr.bazel.build/modules/stardoc/0.5.6/MODULE.bazel": "c43dabc564990eeab55e25ed61c07a1aadafe9ece96a4efabb3f8bf9063b71ef",
+    "https://bcr.bazel.build/modules/stardoc/0.7.0/MODULE.bazel": "05e3d6d30c099b6770e97da986c53bd31844d7f13d41412480ea265ac9e8079c",
+    "https://bcr.bazel.build/modules/stardoc/0.7.1/MODULE.bazel": "3548faea4ee5dda5580f9af150e79d0f6aea934fc60c1cc50f4efdd9420759e7",
+    "https://bcr.bazel.build/modules/stardoc/0.7.1/source.json": "b6500ffcd7b48cd72c29bb67bcac781e12701cc0d6d55d266a652583cfcdab01",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
-    "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/source.json": "f1ef7d3f9e0e26d4b23d1c39b5f5de71f584dd7d1b4ef83d9bbba6ec7a6a6459",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
-    "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
-    "https://bcr.bazel.build/modules/zlib/1.3/MODULE.bazel": "6a9c02f19a24dcedb05572b2381446e27c272cd383aed11d41d99da9e3167a72",
-    "https://bcr.bazel.build/modules/zlib/1.3/source.json": "b6b43d0737af846022636e6e255fd4a96fee0d34f08f3830e6e0bac51465c37c"
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/MODULE.bazel": "af322bc08976524477c79d1e45e241b6efbeb918c497e8840b8ab116802dda79",
+    "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.3/source.json": "2be409ac3c7601245958cd4fcdff4288be79ed23bd690b4b951f500d54ee6e7d",
+    "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
-    "@@apple_support~//crosstool:setup.bzl%apple_cc_configure_extension": {
-      "general": {
-        "bzlTransitiveDigest": "PjIds3feoYE8SGbbIq2SFTZy3zmxeO2tQevJZNDo7iY=",
-        "usagesDigest": "aLmqbvowmHkkBPve05yyDNGN7oh7QE9kBADr3QIZTZs=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "local_config_apple_cc": {
-            "bzlFile": "@@apple_support~//crosstool:setup.bzl",
-            "ruleClassName": "_apple_cc_autoconf",
-            "attributes": {}
-          },
-          "local_config_apple_cc_toolchains": {
-            "bzlFile": "@@apple_support~//crosstool:setup.bzl",
-            "ruleClassName": "_apple_cc_autoconf_toolchains",
-            "attributes": {}
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "apple_support~",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
-      }
-    },
     "@@platforms//host:extension.bzl%host_platform": {
       "general": {
         "bzlTransitiveDigest": "xelQcPZH8+tmuOHVjL9vDxMnnQNMlwj0SlvgoqBkm4U=",
-        "usagesDigest": "meSzxn3DUCcYEhq4HQwExWkWtU4EjriRBQLsZN+Q0SU=",
+        "usagesDigest": "SeQiIN/f8/Qt9vYQk7qcXp4I4wJeEC0RnQDiaaJ4tb8=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
           "host_platform": {
-            "bzlFile": "@@platforms//host:extension.bzl",
-            "ruleClassName": "host_platform_repo",
+            "repoRuleId": "@@platforms//host:extension.bzl%host_platform_repo",
             "attributes": {}
           }
         },
         "recordedRepoMappingEntries": []
       }
     },
-    "@@rules_python~//python/extensions:python.bzl%python": {
+    "@@rules_java+//java:rules_java_deps.bzl%compatibility_proxy": {
       "general": {
-        "bzlTransitiveDigest": "XaaZIw4dO4l6naftU5IBdrfCE1mOmelaT/Sq9uyBnhs=",
-        "usagesDigest": "XRXGQ1YSlgZzzO0pux+3DEHfP/c70L/kznvRIwakvlw=",
+        "bzlTransitiveDigest": "84xJEZ1jnXXwo8BXMprvBm++rRt4jsTu9liBxz0ivps=",
+        "usagesDigest": "jTQDdLDxsS43zuRmg1faAjIEPWdLAbDAowI1pInQSoo=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
-          "python_3_11_aarch64-unknown-linux-gnu": {
-            "bzlFile": "@@rules_python~//python:repositories.bzl",
-            "ruleClassName": "python_repository",
+          "compatibility_proxy": {
+            "repoRuleId": "@@rules_java+//java:rules_java_deps.bzl%_compatibility_proxy_repo_rule",
+            "attributes": {}
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_java+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
+      "general": {
+        "bzlTransitiveDigest": "sFhcgPbDQehmbD1EOXzX4H1q/CD5df8zwG4kp4jbvr8=",
+        "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_github_jetbrains_kotlin_git": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_compiler_git_repository",
             "attributes": {
-              "sha256": "debf15783bdcb5530504f533d33fda75a7b905cec5361ae8f33da5ba6599f8b4",
-              "patches": [],
-              "platform": "aarch64-unknown-linux-gnu",
-              "python_version": "3.11.1",
-              "release_filename": "20230116/cpython-3.11.1+20230116-aarch64-unknown-linux-gnu-install_only.tar.gz",
               "urls": [
-                "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1+20230116-aarch64-unknown-linux-gnu-install_only.tar.gz"
+                "https://github.com/JetBrains/kotlin/releases/download/v1.9.23/kotlin-compiler-1.9.23.zip"
               ],
-              "distutils_content": "",
-              "strip_prefix": "python",
-              "ignore_root_user_error": false
+              "sha256": "93137d3aab9afa9b27cb06a824c2324195c6b6f6179d8a8653f440f5bd58be88"
             }
           },
-          "python_3_9": {
-            "bzlFile": "@@rules_python~//python/private:toolchains_repo.bzl",
-            "ruleClassName": "toolchain_aliases",
+          "com_github_jetbrains_kotlin": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_capabilities_repository",
             "attributes": {
-              "python_version": "3.9.16",
-              "user_repository_name": "python_3_9"
+              "git_repository_name": "com_github_jetbrains_kotlin_git",
+              "compiler_version": "1.9.23"
             }
           },
-          "python_3_11_aarch64-apple-darwin": {
-            "bzlFile": "@@rules_python~//python:repositories.bzl",
-            "ruleClassName": "python_repository",
+          "com_github_google_ksp": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:ksp.bzl%ksp_compiler_plugin_repository",
             "attributes": {
-              "sha256": "4918cdf1cab742a90f85318f88b8122aeaa2d04705803c7b6e78e81a3dd40f80",
-              "patches": [],
-              "platform": "aarch64-apple-darwin",
-              "python_version": "3.11.1",
-              "release_filename": "20230116/cpython-3.11.1+20230116-aarch64-apple-darwin-install_only.tar.gz",
               "urls": [
-                "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1+20230116-aarch64-apple-darwin-install_only.tar.gz"
+                "https://github.com/google/ksp/releases/download/1.9.23-1.0.20/artifacts.zip"
               ],
-              "distutils_content": "",
-              "strip_prefix": "python",
-              "ignore_root_user_error": false
+              "sha256": "ee0618755913ef7fd6511288a232e8fad24838b9af6ea73972a76e81053c8c2d",
+              "strip_version": "1.9.23-1.0.20"
             }
           },
-          "pythons_hub": {
-            "bzlFile": "@@rules_python~//python/extensions/private:pythons_hub.bzl",
-            "ruleClassName": "hub_repo",
+          "com_github_pinterest_ktlint": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
-              "toolchain_prefixes": [
-                "_0000_python_3_9_",
-                "_0001_python_3_11_"
+              "sha256": "01b2e0ef893383a50dbeb13970fe7fa3be36ca3e83259e01649945b09d736985",
+              "urls": [
+                "https://github.com/pinterest/ktlint/releases/download/1.3.0/ktlint"
               ],
-              "toolchain_python_versions": [
-                "3.9",
-                "3.11"
-              ],
-              "toolchain_set_python_version_constraints": [
-                "True",
-                "False"
-              ],
-              "toolchain_user_repository_names": [
-                "python_3_9",
-                "python_3_11"
+              "executable": true
+            }
+          },
+          "rules_android": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
+              "strip_prefix": "rules_android-0.1.1",
+              "urls": [
+                "https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"
               ]
-            }
-          },
-          "python_3_11_x86_64-pc-windows-msvc": {
-            "bzlFile": "@@rules_python~//python:repositories.bzl",
-            "ruleClassName": "python_repository",
-            "attributes": {
-              "sha256": "edc08979cb0666a597466176511529c049a6f0bba8adf70df441708f766de5bf",
-              "patches": [],
-              "platform": "x86_64-pc-windows-msvc",
-              "python_version": "3.11.1",
-              "release_filename": "20230116/cpython-3.11.1+20230116-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-              "urls": [
-                "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1+20230116-x86_64-pc-windows-msvc-shared-install_only.tar.gz"
-              ],
-              "distutils_content": "",
-              "strip_prefix": "python",
-              "ignore_root_user_error": false
-            }
-          },
-          "python_3_9_aarch64-apple-darwin": {
-            "bzlFile": "@@rules_python~//python:repositories.bzl",
-            "ruleClassName": "python_repository",
-            "attributes": {
-              "sha256": "c1de1d854717a6245f45262ef1bb17b09e2c587590e7e3f406593c143ff875bd",
-              "patches": [],
-              "platform": "aarch64-apple-darwin",
-              "python_version": "3.9.16",
-              "release_filename": "20230507/cpython-3.9.16+20230507-aarch64-apple-darwin-install_only.tar.gz",
-              "urls": [
-                "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16+20230507-aarch64-apple-darwin-install_only.tar.gz"
-              ],
-              "distutils_content": "",
-              "strip_prefix": "python",
-              "ignore_root_user_error": false
-            }
-          },
-          "python_3_9_x86_64-pc-windows-msvc": {
-            "bzlFile": "@@rules_python~//python:repositories.bzl",
-            "ruleClassName": "python_repository",
-            "attributes": {
-              "sha256": "cdabb47204e96ce7ea31fbd0b5ed586114dd7d8f8eddf60a509a7f70b48a1c5e",
-              "patches": [],
-              "platform": "x86_64-pc-windows-msvc",
-              "python_version": "3.9.16",
-              "release_filename": "20230507/cpython-3.9.16+20230507-x86_64-pc-windows-msvc-shared-install_only.tar.gz",
-              "urls": [
-                "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16+20230507-x86_64-pc-windows-msvc-shared-install_only.tar.gz"
-              ],
-              "distutils_content": "",
-              "strip_prefix": "python",
-              "ignore_root_user_error": false
-            }
-          },
-          "python_3_9_ppc64le-unknown-linux-gnu": {
-            "bzlFile": "@@rules_python~//python:repositories.bzl",
-            "ruleClassName": "python_repository",
-            "attributes": {
-              "sha256": "ff3ac35c58f67839aff9b5185a976abd3d1abbe61af02089f7105e876c1fe284",
-              "patches": [],
-              "platform": "ppc64le-unknown-linux-gnu",
-              "python_version": "3.9.16",
-              "release_filename": "20230507/cpython-3.9.16+20230507-ppc64le-unknown-linux-gnu-install_only.tar.gz",
-              "urls": [
-                "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16+20230507-ppc64le-unknown-linux-gnu-install_only.tar.gz"
-              ],
-              "distutils_content": "",
-              "strip_prefix": "python",
-              "ignore_root_user_error": false
-            }
-          },
-          "python_3_9_aarch64-unknown-linux-gnu": {
-            "bzlFile": "@@rules_python~//python:repositories.bzl",
-            "ruleClassName": "python_repository",
-            "attributes": {
-              "sha256": "f629b75ebfcafe9ceee2e796b7e4df5cf8dbd14f3c021afca078d159ab797acf",
-              "patches": [],
-              "platform": "aarch64-unknown-linux-gnu",
-              "python_version": "3.9.16",
-              "release_filename": "20230507/cpython-3.9.16+20230507-aarch64-unknown-linux-gnu-install_only.tar.gz",
-              "urls": [
-                "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16+20230507-aarch64-unknown-linux-gnu-install_only.tar.gz"
-              ],
-              "distutils_content": "",
-              "strip_prefix": "python",
-              "ignore_root_user_error": false
-            }
-          },
-          "python_aliases": {
-            "bzlFile": "@@rules_python~//python/private:toolchains_repo.bzl",
-            "ruleClassName": "multi_toolchain_aliases",
-            "attributes": {
-              "python_versions": {
-                "3.9": "python_3_9",
-                "3.11": "python_3_11"
-              }
-            }
-          },
-          "python_3_11": {
-            "bzlFile": "@@rules_python~//python/private:toolchains_repo.bzl",
-            "ruleClassName": "toolchain_aliases",
-            "attributes": {
-              "python_version": "3.11.1",
-              "user_repository_name": "python_3_11"
-            }
-          },
-          "python_3_11_x86_64-apple-darwin": {
-            "bzlFile": "@@rules_python~//python:repositories.bzl",
-            "ruleClassName": "python_repository",
-            "attributes": {
-              "sha256": "20a4203d069dc9b710f70b09e7da2ce6f473d6b1110f9535fb6f4c469ed54733",
-              "patches": [],
-              "platform": "x86_64-apple-darwin",
-              "python_version": "3.11.1",
-              "release_filename": "20230116/cpython-3.11.1+20230116-x86_64-apple-darwin-install_only.tar.gz",
-              "urls": [
-                "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1+20230116-x86_64-apple-darwin-install_only.tar.gz"
-              ],
-              "distutils_content": "",
-              "strip_prefix": "python",
-              "ignore_root_user_error": false
-            }
-          },
-          "python_3_9_x86_64-apple-darwin": {
-            "bzlFile": "@@rules_python~//python:repositories.bzl",
-            "ruleClassName": "python_repository",
-            "attributes": {
-              "sha256": "3abc4d5fbbc80f5f848f280927ac5d13de8dc03aabb6ae65d8247cbb68e6f6bf",
-              "patches": [],
-              "platform": "x86_64-apple-darwin",
-              "python_version": "3.9.16",
-              "release_filename": "20230507/cpython-3.9.16+20230507-x86_64-apple-darwin-install_only.tar.gz",
-              "urls": [
-                "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16+20230507-x86_64-apple-darwin-install_only.tar.gz"
-              ],
-              "distutils_content": "",
-              "strip_prefix": "python",
-              "ignore_root_user_error": false
-            }
-          },
-          "python_3_9_x86_64-unknown-linux-gnu": {
-            "bzlFile": "@@rules_python~//python:repositories.bzl",
-            "ruleClassName": "python_repository",
-            "attributes": {
-              "sha256": "2b6e146234a4ef2a8946081fc3fbfffe0765b80b690425a49ebe40b47c33445b",
-              "patches": [],
-              "platform": "x86_64-unknown-linux-gnu",
-              "python_version": "3.9.16",
-              "release_filename": "20230507/cpython-3.9.16+20230507-x86_64-unknown-linux-gnu-install_only.tar.gz",
-              "urls": [
-                "https://github.com/indygreg/python-build-standalone/releases/download/20230507/cpython-3.9.16+20230507-x86_64-unknown-linux-gnu-install_only.tar.gz"
-              ],
-              "distutils_content": "",
-              "strip_prefix": "python",
-              "ignore_root_user_error": false
-            }
-          },
-          "python_3_11_x86_64-unknown-linux-gnu": {
-            "bzlFile": "@@rules_python~//python:repositories.bzl",
-            "ruleClassName": "python_repository",
-            "attributes": {
-              "sha256": "02a551fefab3750effd0e156c25446547c238688a32fabde2995c941c03a6423",
-              "patches": [],
-              "platform": "x86_64-unknown-linux-gnu",
-              "python_version": "3.11.1",
-              "release_filename": "20230116/cpython-3.11.1+20230116-x86_64-unknown-linux-gnu-install_only.tar.gz",
-              "urls": [
-                "https://github.com/indygreg/python-build-standalone/releases/download/20230116/cpython-3.11.1+20230116-x86_64-unknown-linux-gnu-install_only.tar.gz"
-              ],
-              "distutils_content": "",
-              "strip_prefix": "python",
-              "ignore_root_user_error": false
             }
           }
         },
         "recordedRepoMappingEntries": [
           [
-            "rules_python~",
+            "rules_kotlin+",
             "bazel_tools",
             "bazel_tools"
           ]

--- a/include/jsonrpc/client/client.hpp
+++ b/include/jsonrpc/client/client.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <future>
 #include <memory>
 #include <mutex>
@@ -72,15 +73,20 @@ class Client {
    * @brief Sends a JSON-RPC method call and waits for the response.
    *
    * This is a blocking call that sends a method request to the server and waits
-   * for the corresponding response.
+   * for the corresponding response. If no response is received within the
+   * timeout period, throws a runtime_error.
    *
    * @param method The name of the method to call.
    * @param params Optional parameters to pass to the method.
+   * @param timeout Maximum time to wait for response.
    * @return The JSON response received from the server.
+   * @throws std::runtime_error if the request times out.
    */
   auto SendMethodCall(
       const std::string &method,
-      std::optional<nlohmann::json> params = std::nullopt) -> nlohmann::json;
+      std::optional<nlohmann::json> params = std::nullopt,
+      std::chrono::milliseconds timeout = std::chrono::seconds(30))
+      -> nlohmann::json;
 
   /**
    * @brief Sends a JSON-RPC method call asynchronously.

--- a/include/jsonrpc/client/client.hpp
+++ b/include/jsonrpc/client/client.hpp
@@ -12,6 +12,7 @@
 #include <nlohmann/json_fwd.hpp>
 
 #include "jsonrpc/client/request.hpp"
+#include "jsonrpc/server/types.hpp"
 #include "jsonrpc/transport/transport.hpp"
 
 namespace jsonrpc::client {
@@ -115,6 +116,15 @@ class Client {
    */
   auto HasPendingRequests() const -> bool;
 
+  /**
+   * @brief Registers a handler for notifications received from the server.
+   *
+   * @param method The name of the notification method to handle.
+   * @param handler The function to handle the notification.
+   */
+  void RegisterNotification(
+      const std::string &method, const server::NotificationHandler &handler);
+
  private:
   /// @brief Listener thread function for receiving responses from the transport
   /// layer.
@@ -189,6 +199,13 @@ class Client {
 
   /// Flag to control the running state of the listener thread.
   std::atomic<bool> is_running_{false};
+
+  /// Map of notification handlers
+  std::unordered_map<std::string, server::NotificationHandler>
+      notification_handlers_;
+
+  /// Mutex to protect access to the notification handlers map
+  mutable std::mutex notification_handlers_mutex_;
 };
 
 }  // namespace jsonrpc::client

--- a/include/jsonrpc/server/server.hpp
+++ b/include/jsonrpc/server/server.hpp
@@ -2,7 +2,11 @@
 
 #include <atomic>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <string>
+
+#include <nlohmann/json_fwd.hpp>
 
 #include "jsonrpc/server/dispatcher.hpp"
 #include "jsonrpc/server/types.hpp"
@@ -54,6 +58,16 @@ class Server {
   void RegisterNotification(
       const std::string &method, const NotificationHandler &handler);
 
+  /**
+   * @brief Sends a notification to the client.
+   *
+   * @param method The name of the notification method.
+   * @param params Optional parameters to include in the notification.
+   */
+  void SendNotification(
+      const std::string &method,
+      std::optional<nlohmann::json> params = std::nullopt);
+
   /// @brief Checks if the server is currently running.
   [[nodiscard]] auto IsRunning() const -> bool;
 
@@ -66,6 +80,9 @@ class Server {
 
   /// Transport layer for communication.
   std::unique_ptr<transport::Transport> transport_;
+
+  /// Mutex to protect transport access
+  mutable std::mutex transport_mutex_;
 
   /// Flag indicating if the server is running.
   std::atomic<bool> running_{false};

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -35,10 +35,12 @@ auto Client::HasPendingRequests() const -> bool {
 void Client::Listener() {
   spdlog::info("Starting JSON-RPC client listener thread");
   while (is_running_) {
-    if (expected_count_ > 0) {
-      std::string response = transport_->ReceiveMessage();
+    std::string response = transport_->ReceiveMessage();
+    if (!response.empty()) {
       HandleResponse(response);
-      expected_count_--;
+      if (expected_count_ > 0) {  // Only decrement for method call responses
+        expected_count_--;
+      }
     }
   }
 }
@@ -108,6 +110,32 @@ void Client::HandleResponse(const std::string &response) {
         "Failed to parse JSON response: " + std::string(e.what()));
   }
 
+  // Check if this is a notification (no "id" field)
+  if (json_response.contains("method")) {
+    // This is a notification from server
+    try {
+      const std::string &method = json_response["method"].get<std::string>();
+      std::lock_guard<std::mutex> lock(notification_handlers_mutex_);
+      auto it = notification_handlers_.find(method);
+      if (it != notification_handlers_.end()) {
+        // Extract params if they exist
+        nlohmann::json params = json_response.contains("params")
+                                    ? json_response["params"]
+                                    : nlohmann::json::object();
+        it->second(params);
+      } else {
+        spdlog::warn(
+            "No handler registered for notification method: {}", method);
+      }
+      return;  // Exit early for notifications
+    } catch (const std::exception &e) {
+      spdlog::error("Error handling notification: {}", e.what());
+      throw std::runtime_error(
+          "Error handling notification: " + std::string(e.what()));
+    }
+  }
+
+  // Handle regular responses
   if (ValidateResponse(json_response)) {
     int request_id = json_response["id"].get<int>();
 
@@ -154,6 +182,19 @@ auto Client::ValidateResponse(const nlohmann::json &response) -> bool {
   }
 
   return true;
+}
+
+void Client::RegisterNotification(
+    const std::string &method, const server::NotificationHandler &handler) {
+  std::lock_guard<std::mutex> lock(notification_handlers_mutex_);
+  if (handler) {
+    notification_handlers_[method] = handler;
+    spdlog::debug("Registered handler for notification method: {}", method);
+  } else {
+    // If handler is null, remove the registration
+    notification_handlers_.erase(method);
+    spdlog::debug("Unregistered handler for notification method: {}", method);
+  }
 }
 
 }  // namespace jsonrpc::client

--- a/src/client/client.cpp
+++ b/src/client/client.cpp
@@ -46,12 +46,23 @@ void Client::Listener() {
 }
 
 auto Client::SendMethodCall(
-    const std::string &method,
-    std::optional<nlohmann::json> params) -> nlohmann::json {
+    const std::string &method, std::optional<nlohmann::json> params,
+    std::chrono::milliseconds timeout) -> nlohmann::json {
   Request request(method, std::move(params), false, [this]() {
     return GetNextRequestId();
   });
-  return SendRequest(request);
+  auto future = SendRequestAsync(request);
+
+  if (future.wait_for(timeout) != std::future_status::ready) {
+    // Remove the pending request since we're timing out
+    {
+      std::lock_guard<std::mutex> lock(requests_mutex_);
+      requests_map_.erase(request.GetKey());
+    }
+    throw std::runtime_error(fmt::format(
+        "Request timed out after {} ms: {}", timeout.count(), method));
+  }
+  return future.get();
 }
 
 auto Client::SendMethodCallAsync(

--- a/src/server/server.cpp
+++ b/src/server/server.cpp
@@ -36,12 +36,19 @@ void Server::Listen() {
   }
 
   while (IsRunning()) {
-    std::string request = transport_->ReceiveMessage();
+    std::string request;
+    {
+      std::lock_guard<std::mutex> lock(transport_mutex_);
+      request = transport_->ReceiveMessage();
+    }
+
     if (request.empty()) {
       continue;
     }
+
     std::optional<std::string> response = dispatcher_->DispatchRequest(request);
     if (response.has_value()) {
+      std::lock_guard<std::mutex> lock(transport_mutex_);
       transport_->SendMessage(response.value());
     }
   }
@@ -55,6 +62,40 @@ void Server::RegisterMethodCall(
 void Server::RegisterNotification(
     const std::string &method, const NotificationHandler &handler) {
   dispatcher_->RegisterNotification(method, handler);
+}
+
+void Server::SendNotification(
+    const std::string &method, std::optional<nlohmann::json> params) {
+  if (!transport_) {
+    throw std::runtime_error("Transport is not initialized");
+  }
+
+  if (!IsRunning()) {
+    throw std::runtime_error("Server is not running");
+  }
+
+  try {
+    // Construct JSON-RPC notification message
+    nlohmann::json notification = {{"jsonrpc", "2.0"}, {"method", method}};
+
+    // Only add params if they are provided
+    if (params.has_value()) {
+      notification["params"] = params.value();
+    }
+
+    // Convert JSON to string and send with thread safety
+    const auto message = notification.dump();
+    {
+      std::lock_guard<std::mutex> lock(transport_mutex_);
+      transport_->SendMessage(message);
+    }
+  } catch (const nlohmann::json::exception &e) {
+    throw std::runtime_error(
+        std::string("Failed to create notification message: ") + e.what());
+  } catch (const std::exception &e) {
+    throw std::runtime_error(
+        std::string("Failed to send notification: ") + e.what());
+  }
 }
 
 }  // namespace jsonrpc::server

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,5 +1,14 @@
 # tests/BUILD
 
+# Mock transport library
+cc_library(
+    name = "mock_transport",
+    hdrs = ["common/mock_transport.hpp"],
+    deps = [
+        "//src:jsonrpc_lib",
+    ],
+)
+
 # Client
 cc_test(
     name = "test_client",
@@ -8,8 +17,10 @@ cc_test(
         "client/test_client.cpp",
         "common/mock_transport.hpp",
     ],
+    defines = ["TESTING"],
     deps = [
         "//src:jsonrpc_lib",
+        "//tests:mock_transport",
         "@catch2//:catch2_main",
     ],
 )

--- a/tests/client/test_client.cpp
+++ b/tests/client/test_client.cpp
@@ -1,3 +1,6 @@
+#include <memory>
+#include <thread>
+
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <fmt/core.h>
@@ -5,6 +8,8 @@
 
 #include "../common/mock_transport.hpp"
 #include "jsonrpc/client/client.hpp"
+
+using Json = nlohmann::json;
 
 TEST_CASE("Client starts and stops correctly", "[Client]") {
   auto transport = std::make_unique<MockTransport>();
@@ -37,7 +42,7 @@ TEST_CASE("Client handles responses correctly", "[Client]") {
 TEST_CASE(
     "Client sends notification without expecting a response", "[Client]") {
   auto transport = std::make_unique<MockTransport>();
-  MockTransport *transport_ptr = transport.get();
+  MockTransport* transport_ptr = transport.get();
 
   jsonrpc::client::Client client(std::move(transport));
   client.Start();
@@ -56,7 +61,7 @@ TEST_CASE(
 
 TEST_CASE("Client handles valid JSON-RPC response", "[Client]") {
   auto transport = std::make_unique<MockTransport>();
-  MockTransport *transport_ptr = transport.get();
+  MockTransport* transport_ptr = transport.get();
 
   transport_ptr->SetResponse(
       R"({"jsonrpc":"2.0","result":{"data":"success"},"id":0})");
@@ -77,20 +82,21 @@ TEST_CASE("Client handles valid JSON-RPC response", "[Client]") {
 
 TEST_CASE("Client handles in-order responses correctly", "[Client][InOrder]") {
   auto transport = std::make_unique<MockTransport>();
-  MockTransport *transport_ptr = transport.get();
+  MockTransport* transport_ptr = transport.get();
 
   const int num_requests = 10;
+  std::vector<std::string> responses;
   for (int i = 0; i < num_requests; ++i) {
-    std::string response = fmt::format(
+    responses.push_back(fmt::format(
         R"({{"jsonrpc":"2.0","result":{{"data":"success_{}"}},"id":{}}})", i,
-        i);
-    transport_ptr->SetResponse(response);
+        i));
   }
 
   jsonrpc::client::Client client(std::move(transport));
   client.Start();
 
   for (int i = 0; i < num_requests; ++i) {
+    transport_ptr->SetResponse(responses[i]);
     REQUIRE(client.HasPendingRequests() == false);
     auto response = client.SendMethodCall("getData");
     REQUIRE(client.HasPendingRequests() == false);
@@ -102,7 +108,7 @@ TEST_CASE("Client handles in-order responses correctly", "[Client][InOrder]") {
 
 TEST_CASE("Client handles async method calls correctly", "[Client][Async]") {
   auto transport = std::make_unique<MockTransport>();
-  MockTransport *transport_ptr = transport.get();
+  MockTransport* transport_ptr = transport.get();
 
   transport_ptr->SetResponse(
       R"({"jsonrpc":"2.0","result":"async_success","id":0})");
@@ -128,7 +134,7 @@ TEST_CASE(
     "Client handles multiple async method calls concurrently",
     "[Client][Async]") {
   auto transport = std::make_unique<MockTransport>();
-  MockTransport *transport_ptr = transport.get();
+  MockTransport* transport_ptr = transport.get();
 
   const int num_requests = 5;
   for (int i = 0; i < num_requests; ++i) {
@@ -157,4 +163,118 @@ TEST_CASE(
   REQUIRE(client.HasPendingRequests() == false);
 
   client.Stop();
+}
+
+TEST_CASE("Client can handle server notifications", "[Client]") {
+  SECTION("Client processes notifications without params") {
+    auto mock_transport = std::make_unique<MockTransport>();
+    auto* transport_ptr = mock_transport.get();
+    jsonrpc::client::Client client(std::move(mock_transport));
+
+    bool notification_received = false;
+    client.RegisterNotification(
+        "test_notification",
+        [&notification_received](
+            [[maybe_unused]] const std::optional<nlohmann::json>& params) {
+          notification_received = true;
+        });
+
+    client.Start();
+
+    // Simulate server sending a notification
+    Json notification = {{"jsonrpc", "2.0"}, {"method", "test_notification"}};
+    transport_ptr->SetResponse(notification.dump());
+
+    // Give some time for the client to process
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    client.Stop();
+
+    REQUIRE(notification_received);
+  }
+
+  SECTION("Client processes notifications with params") {
+    auto mock_transport = std::make_unique<MockTransport>();
+    auto* transport_ptr = mock_transport.get();
+    jsonrpc::client::Client client(std::move(mock_transport));
+
+    Json received_params;
+    client.RegisterNotification(
+        "test_notification",
+        [&received_params](const std::optional<nlohmann::json>& params) {
+          REQUIRE(params.has_value());
+          received_params = params.value();
+        });
+
+    client.Start();
+
+    // Simulate server sending a notification with params
+    Json notification = {
+        {"jsonrpc", "2.0"},
+        {"method", "test_notification"},
+        {"params", {{"key1", "value1"}, {"key2", 42}}}};
+    transport_ptr->SetResponse(notification.dump());
+
+    // Give some time for the client to process
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    client.Stop();
+
+    REQUIRE(received_params["key1"] == "value1");
+    REQUIRE(received_params["key2"] == 42);
+  }
+
+  SECTION("Client handles unregistered notifications gracefully") {
+    auto mock_transport = std::make_unique<MockTransport>();
+    auto* transport_ptr = mock_transport.get();
+    jsonrpc::client::Client client(std::move(mock_transport));
+
+    client.Start();
+
+    // Simulate server sending a notification for unregistered method
+    Json notification = {
+        {"jsonrpc", "2.0"},
+        {"method", "unknown_notification"},
+        {"params", {{"data", "test"}}}};
+    transport_ptr->SetResponse(notification.dump());
+
+    // Should not crash
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    client.Stop();
+  }
+
+  SECTION("Client can handle notifications while processing method calls") {
+    auto mock_transport = std::make_unique<MockTransport>();
+    auto* transport_ptr = mock_transport.get();
+    jsonrpc::client::Client client(std::move(mock_transport));
+
+    bool notification_received = false;
+    client.RegisterNotification(
+        "test_notification",
+        [&notification_received](
+            [[maybe_unused]] const std::optional<nlohmann::json>& params) {
+          notification_received = true;
+        });
+
+    client.Start();
+
+    // Start an async method call
+    auto future = client.SendMethodCallAsync("test_method", Json::object());
+
+    // Simulate server sending a notification before the response
+    Json notification = {{"jsonrpc", "2.0"}, {"method", "test_notification"}};
+    transport_ptr->SetResponse(notification.dump());
+
+    // Then simulate the method response
+    Json response = {
+        {"jsonrpc", "2.0"},
+        {"id", 0},  // First request will always have ID 0
+        {"result", "success"}};
+    transport_ptr->SetResponse(response.dump());
+
+    // Wait for both to be processed
+    future.get();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    client.Stop();
+
+    REQUIRE(notification_received);
+  }
 }

--- a/tests/client/test_client.cpp
+++ b/tests/client/test_client.cpp
@@ -278,3 +278,52 @@ TEST_CASE("Client can handle server notifications", "[Client]") {
     REQUIRE(notification_received);
   }
 }
+
+TEST_CASE("Client handles request timeouts correctly", "[Client][Timeout]") {
+  SECTION("Request times out when no response received") {
+    auto transport = std::make_unique<MockTransport>();
+    jsonrpc::client::Client client(std::move(transport));
+    client.Start();
+
+    REQUIRE_THROWS_WITH(
+        client.SendMethodCall(
+            "test_method", nlohmann::json::object(),
+            std::chrono::milliseconds(100)),
+        Catch::Matchers::ContainsSubstring("Request timed out after 100 ms"));
+
+    client.Stop();
+  }
+
+  SECTION("Request succeeds when response received within timeout") {
+    auto transport = std::make_unique<MockTransport>();
+    auto* transport_ptr = transport.get();
+    jsonrpc::client::Client client(std::move(transport));
+
+    transport_ptr->SetResponse(
+        R"({"jsonrpc":"2.0","result":"success","id":0})");
+    client.Start();
+
+    REQUIRE_NOTHROW(client.SendMethodCall(
+        "test_method", nlohmann::json::object(),
+        std::chrono::milliseconds(1000)));
+
+    client.Stop();
+  }
+
+  SECTION("Timed out request is removed from pending requests") {
+    auto transport = std::make_unique<MockTransport>();
+    jsonrpc::client::Client client(std::move(transport));
+    client.Start();
+
+    try {
+      client.SendMethodCall(
+          "test_method", nlohmann::json::object(),
+          std::chrono::milliseconds(100));
+    } catch (const std::runtime_error&) {
+      // Expected timeout
+    }
+
+    REQUIRE(client.HasPendingRequests() == false);
+    client.Stop();
+  }
+}

--- a/tests/common/mock_transport.hpp
+++ b/tests/common/mock_transport.hpp
@@ -1,5 +1,5 @@
-
 #include <queue>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -25,5 +25,12 @@ class MockTransport : public jsonrpc::transport::Transport {
 
   void SetResponse(const std::string &response) {
     responses.push(response);
+  }
+
+  auto GetLastSentMessage() const -> const std::string & {
+    if (sent_requests.empty()) {
+      throw std::runtime_error("No messages have been sent");
+    }
+    return sent_requests.back();
   }
 };

--- a/tests/server/test_server.cpp
+++ b/tests/server/test_server.cpp
@@ -1,4 +1,7 @@
 #include <memory>
+#include <stdexcept>
+#include <thread>
+#include <vector>
 
 #include <catch2/catch_test_macros.hpp>
 #include <nlohmann/json.hpp>
@@ -27,4 +30,144 @@ TEST_CASE("Server stops and exits running state", "[Server]") {
   }
 
   REQUIRE(server.IsRunning() == false);
+}
+
+TEST_CASE("Server can send notifications", "[Server]") {
+  auto mock_transport = std::make_unique<MockTransport>();
+  auto* transport_ptr = mock_transport.get();
+  jsonrpc::server::Server server(std::move(mock_transport));
+
+  SECTION("Server can send notification without params") {
+    std::thread server_thread([&server]() { server.Start(); });
+    std::this_thread::sleep_for(
+        std::chrono::milliseconds(100));  // Wait for server to start
+
+    server.SendNotification("test_method");
+
+    server.Stop();
+    if (server_thread.joinable()) {
+      server_thread.join();
+    }
+
+    // Verify the sent message
+    auto sent_message = Json::parse(transport_ptr->GetLastSentMessage());
+    REQUIRE(sent_message["jsonrpc"] == "2.0");
+    REQUIRE(sent_message["method"] == "test_method");
+    REQUIRE(sent_message.contains("params") == false);
+  }
+
+  SECTION("Server can send notification with params") {
+    std::thread server_thread([&server]() { server.Start(); });
+    std::this_thread::sleep_for(
+        std::chrono::milliseconds(100));  // Wait for server to start
+
+    Json params = {{"key1", "value1"}, {"key2", 42}};
+    server.SendNotification("test_method", params);
+
+    server.Stop();
+    if (server_thread.joinable()) {
+      server_thread.join();
+    }
+
+    // Verify the sent message
+    auto sent_message = Json::parse(transport_ptr->GetLastSentMessage());
+    REQUIRE(sent_message["jsonrpc"] == "2.0");
+    REQUIRE(sent_message["method"] == "test_method");
+    REQUIRE(sent_message["params"]["key1"] == "value1");
+    REQUIRE(sent_message["params"]["key2"] == 42);
+  }
+
+  SECTION("Server throws when sending notification while not running") {
+    REQUIRE_THROWS_AS(
+        server.SendNotification("test_method"), std::runtime_error);
+  }
+}
+
+TEST_CASE("Server handles concurrent transport access safely", "[Server]") {
+  auto mock_transport = std::make_unique<MockTransport>();
+  auto* transport_ptr = mock_transport.get();
+  jsonrpc::server::Server server(std::move(mock_transport));
+
+  SECTION("Multiple threads can send notifications concurrently") {
+    std::thread server_thread([&server]() { server.Start(); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    const int num_threads = 10;
+    std::vector<std::thread> notification_threads;
+
+    // Launch multiple threads to send notifications
+    for (int i = 0; i < num_threads; ++i) {
+      notification_threads.emplace_back([&server, i]() {
+        Json params = {{"thread_id", i}};
+        server.SendNotification("test_method", params);
+      });
+    }
+
+    // Wait for all notifications to complete
+    for (auto& thread : notification_threads) {
+      thread.join();
+    }
+
+    server.Stop();
+    server_thread.join();
+
+    // Verify all notifications were sent
+    const auto& sent_messages = transport_ptr->sent_requests;
+    REQUIRE(sent_messages.size() == num_threads);
+
+    // Verify each message is valid JSON-RPC 2.0 notification
+    for (const auto& msg : sent_messages) {
+      auto json = Json::parse(msg);
+      REQUIRE(json["jsonrpc"] == "2.0");
+      REQUIRE(json["method"] == "test_method");
+      REQUIRE(json.contains("params"));
+      REQUIRE(json["params"]["thread_id"].is_number());
+    }
+  }
+
+  SECTION("Server can handle concurrent requests and notifications") {
+    // Register a method that takes some time to process
+    server.RegisterMethodCall(
+        "slow_method",
+        []([[maybe_unused]] const std::optional<nlohmann::json>& params)
+            -> nlohmann::json {
+          std::this_thread::sleep_for(std::chrono::milliseconds(50));
+          return Json{"processed"};
+        });
+
+    std::thread server_thread([&server]() { server.Start(); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // Send a mix of notifications and requests concurrently
+    std::vector<std::thread> mixed_threads;
+    const int num_threads = 5;
+
+    for (int i = 0; i < num_threads; ++i) {
+      // Thread for notification
+      mixed_threads.emplace_back([&server, i]() {
+        Json params = {{"notification_id", i}};
+        server.SendNotification("test_notification", params);
+      });
+
+      // Thread for method call (simulated from transport)
+      mixed_threads.emplace_back([transport_ptr, i]() {
+        Json request = {
+            {"jsonrpc", "2.0"},
+            {"method", "slow_method"},
+            {"id", i},
+            {"params", {{"request_id", i}}}};
+        transport_ptr->SetResponse(request.dump());
+      });
+    }
+
+    for (auto& thread : mixed_threads) {
+      thread.join();
+    }
+
+    server.Stop();
+    server_thread.join();
+
+    // Verify messages were processed
+    REQUIRE(transport_ptr->sent_requests.size() > 0);
+  }
 }

--- a/third_party/thread_pool/BUILD.bazel
+++ b/third_party/thread_pool/BUILD.bazel
@@ -1,6 +1,9 @@
 cc_library(
     name = "thread_pool",
-    hdrs = glob(["include/*.hpp"]),
+    hdrs = glob(
+        ["include/*.hpp"],
+        allow_empty = True,
+    ),
     includes = ["include"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Enhance JSON-RPC server with bidirectional notification capabilities, allowing servers to push notifications to clients. Includes thread-safe implementation for concurrent scenarios.

## Changes
- Add `SendNotification` method to Server class
  - Support notifications with and without params
  - Thread-safe implementation for concurrent calls
- Add comprehensive test suite for notification features
- Enable ccache for faster builds

## Test Coverage
- Basic notification sending (with/without params)
- Concurrent notification handling (10 threads)
- Mixed request/notification scenarios
- Error handling for invalid states

## Build Improvements
- Enable ccache with concurrent build protection
- Update core dependencies to latest stable versions