### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2025-03-09
+
+### Changed
+
+- **BREAKING**: Complete migration from blocking calls to Asio coroutines with awaitable interfaces
+- **BREAKING**: Method signatures now return `asio::awaitable<>` instead of direct values
+- **BREAKING**: Client code must use `co_await` with coroutine functions
+- **BREAKING**: Method handlers must be implemented as coroutines
+- Refactored transport layer to use asynchronous operations throughout
+- Redesigned RPC endpoint to leverage coroutines for all operations
+- Transitioned from thread pools to IO context-based execution
+- Removed manual thread management in favor of asio's task model
+- Improved error handling with exception propagation in coroutines
+
+### Added
+
+- Support for proper cancellation and timeouts via Asio facilities
+- New static factory method `CreateClient` for client initialization
+- Better documentation and examples for the coroutine-based approach
+- LSP client example using TypeScript
+- CMake export configuration for easier integration
+
+### Removed
+
+- Synchronous blocking API methods
+- Thread pool-based execution model
+- Stdio transport (poor fit for asynchronous model)
+
 ## [1.0.0] - 2024-08-16
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.19)
-project(jsonrpc-cpp-lib VERSION 1.0.0 LANGUAGES CXX)
+project(jsonrpc-cpp-lib VERSION 2.0.0 LANGUAGES CXX)
 
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 20)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,7 @@ MODULE.bazel file for the jsonrpc module
 
 module(
     name = "jsonrpc_cpp_lib",
-    version = "1.0.0",
+    version = "2.0.0",
 )
 
 # Dependencies from the Bazel Central Registry

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Bazel provides a streamlined dependency management experience. To include this l
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
   name = "jsonrpc",
-  urls = ["https://github.com/hankhsu1996/jsonrpc-cpp-lib/archive/refs/tags/v1.0.0.tar.gz"],
-  strip_prefix = "jsonrpc-cpp-lib-1.0.0",
+  urls = ["https://github.com/hankhsu1996/jsonrpc-cpp-lib/archive/refs/tags/v2.0.0.tar.gz"],
+  strip_prefix = "jsonrpc-cpp-lib-2.0.0",
   sha256 = "a381dc02ab95c31902077793e926adbb0d8f67eadbc386b03451e952d50f0615",
 )
 ```
@@ -54,7 +54,7 @@ include(FetchContent)
 FetchContent_Declare(
   jsonrpc-cpp-lib
   GIT_REPOSITORY https://github.com/hankhsu1996/jsonrpc-cpp-lib.git
-  GIT_TAG v1.0.0
+  GIT_TAG v2.0.0
 )
 FetchContent_MakeAvailable(jsonrpc-cpp-lib)
 
@@ -100,7 +100,7 @@ For projects using Conan for dependency management, create a `conanfile.txt` in 
 
 ```ini
 [requires]
-jsonrpc-cpp-lib/1.0.0
+jsonrpc-cpp-lib/2.0.0
 
 [generators]
 CMakeDeps

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
 class JsonRpcRecipe(ConanFile):
     """ Conan recipe for jsonrpc-cpp-lib """
     name = "jsonrpc-cpp-lib"
-    version = "1.0.0"
+    version = "2.0.0"
     license = "MIT"
     author = "Shou-Li Hsu <hank850503@gmail.com>"
     url = "https://github.com/hankhsu1996/jsonrpc-cpp-lib"


### PR DESCRIPTION
Update version from 1.0.0 to 2.0.0 across all project files and add changelog entry for the new release. This major version bump reflects breaking changes in the API with the migration to Asio coroutines.

Changes:
- Add version 2.0.0 changelog entry with breaking changes, improvements and removals
- Update version in CMakeLists.txt
- Update version in MODULE.bazel
- Update version in conanfile.py
- Update version references in README.md installation instructions
