### PR TITLE
Bump version to 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2025-03-13
+
+### Changed
+
+- Update Catch2 from 3.6.0 to 3.8.0
+- Update spdlog from 1.14.1 to 1.15.1
+- Update asio from 1.28.2 to 1.32.0
+- Update bazel_skylib from 1.5.0 to 1.7.1
+- Modify CMakePresets.json to use Clang compiler by default, resolving batch processing memory allocation issues experienced with GCC
+
 ## [2.0.1] - 2025-03-09
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.19)
-project(jsonrpc-cpp-lib VERSION 2.0.1 LANGUAGES CXX)
+project(jsonrpc-cpp-lib VERSION 2.0.2 LANGUAGES CXX)
 
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 20)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,8 @@ MODULE.bazel file for the jsonrpc module
 
 module(
     name = "jsonrpc_cpp_lib",
-    version = "2.0.1",
+    version = "2.0.2",
+    compatibility_level = 1,
 )
 
 # Dependencies from the Bazel Central Registry

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ bazel_dep(name = "jsonrpc_cpp_lib", version = "0.0.0")
 git_override(
     module_name = "jsonrpc_cpp_lib",
     remote = "https://github.com/hankhsu1996/jsonrpc-cpp-lib.git",
-    tag = "v2.0.1"
+    tag = "v2.0.2"
 )
 ```
 
@@ -56,7 +56,7 @@ include(FetchContent)
 FetchContent_Declare(
   jsonrpc-cpp-lib
   GIT_REPOSITORY https://github.com/hankhsu1996/jsonrpc-cpp-lib.git
-  GIT_TAG v2.0.1
+  GIT_TAG v2.0.2
 )
 FetchContent_MakeAvailable(jsonrpc-cpp-lib)
 
@@ -102,7 +102,7 @@ For projects using Conan for dependency management, create a `conanfile.txt` in 
 
 ```ini
 [requires]
-jsonrpc-cpp-lib/2.0.1
+jsonrpc-cpp-lib/2.0.2
 
 [generators]
 CMakeDeps

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
 class JsonRpcRecipe(ConanFile):
     """ Conan recipe for jsonrpc-cpp-lib """
     name = "jsonrpc-cpp-lib"
-    version = "2.0.1"
+    version = "2.0.2"
     license = "MIT"
     author = "Shou-Li Hsu <hank850503@gmail.com>"
     url = "https://github.com/hankhsu1996/jsonrpc-cpp-lib"


### PR DESCRIPTION
Update dependency versions and switch to Clang compiler by default.

- Update Catch2 from 3.6.0 to 3.8.0
- Update spdlog from 1.14.1 to 1.15.1
- Update asio from 1.28.2 to 1.32.0
- Update bazel_skylib from 1.5.0 to 1.7.1
- Modify CMakePresets.json to use Clang compiler by default