### PR TITLE
Bump version to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.0] - 2025-03-16
+
+### Changed
+
+- Renamed project from "jsonrpc-cpp-lib" to simply "jsonrpc" for cleaner integration
+- Simplified CMake installation process for better reliability
+
 ## [2.0.2] - 2025-03-13
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.19)
-project(jsonrpc VERSION 2.0.2 LANGUAGES CXX)
+project(jsonrpc VERSION 2.1.0 LANGUAGES CXX)
 
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 20)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,7 +4,7 @@ MODULE.bazel file for the jsonrpc module
 
 module(
     name = "jsonrpc",
-    version = "2.0.2",
+    version = "2.1.0",
     compatibility_level = 1,
 )
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ bazel_dep(name = "jsonrpc", version = "0.0.0")
 git_override(
     module_name = "jsonrpc",
     remote = "https://github.com/hankhsu1996/jsonrpc-cpp-lib.git",
-    tag = "v2.0.2"
+    tag = "v2.1.0"
 )
 ```
 
@@ -56,7 +56,7 @@ include(FetchContent)
 FetchContent_Declare(
   jsonrpc
   GIT_REPOSITORY https://github.com/hankhsu1996/jsonrpc-cpp-lib.git
-  GIT_TAG v2.0.2
+  GIT_TAG v2.1.0
 )
 FetchContent_MakeAvailable(jsonrpc)
 
@@ -102,7 +102,7 @@ For projects using Conan for dependency management, create a `conanfile.txt` in 
 
 ```ini
 [requires]
-jsonrpc/2.0.2
+jsonrpc/2.1.0
 
 [generators]
 CMakeDeps

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
 class JsonRpcRecipe(ConanFile):
     """ Conan recipe for jsonrpc """
     name = "jsonrpc"
-    version = "2.0.2"
+    version = "2.1.0"
     license = "MIT"
     author = "Shou-Li Hsu <hank850503@gmail.com>"
     url = "https://github.com/hankhsu1996/jsonrpc-cpp-lib"


### PR DESCRIPTION

## Changed

- Renamed project from "jsonrpc-cpp-lib" to simply "jsonrpc" for cleaner integration
- Simplified CMake installation process for better reliability
