### PR TITLE
Update Bazel setup action to version 0.14.0 in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.8.5
+        uses: bazel-contrib/setup-bazel@0.14.0
         with:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}


### PR DESCRIPTION
This pull request includes a version update for the Bazel setup in the CI workflow file. The change updates the Bazel setup action to a newer version.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL76-R76): Updated the Bazel setup action from version `0.8.5` to `0.14.0`.