### PR TITLE
Adopt std::expected for error handling overhaul

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,6 +1,6 @@
 CompileFlags:
   Add:
-    - "-std=c++20"
+    - "-std=c++23"
     - "-Wall"
     - "-Wextra"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,15 @@ jobs:
           cache-dependencies: true
           cache-tool: true
 
+      - name: Install Clang 19
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-19
+          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 100
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 100
+          sudo update-alternatives --set clang++ /usr/bin/clang++-19
+          sudo update-alternatives --set clang /usr/bin/clang-19
+
       - name: Install dependencies
         run: |
           conan profile detect --force
@@ -78,6 +87,15 @@ jobs:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
           repository-cache: true
+
+      - name: Install Clang 19
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-19
+          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 100
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 100
+          sudo update-alternatives --set clang++ /usr/bin/clang++-19
+          sudo update-alternatives --set clang /usr/bin/clang-19
 
       - name: Verify Clang is available
         run: clang --version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.19)
 project(jsonrpc VERSION 2.1.1 LANGUAGES CXX)
 
 # Set C++ standard
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # Export compile_commands.json for tools like clangd

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Welcome to the **JSON-RPC 2.0 Modern C++ Library**! This library provides a ligh
 ## Features
 
 - **Fully Compliant with JSON-RPC 2.0**: Supports method calls, notifications, comprehensive error handling, and batch requests.
-- **Modern and Lightweight**: Leverages C++20 features with minimal dependencies, focusing solely on the JSON-RPC protocol.
+- **Modern and Lightweight**: Leverages C++23 features with minimal dependencies, focusing solely on the JSON-RPC protocol.
 - **Unified Endpoint Design**: Single `RpcEndpoint` class that can act as both client and server, following JSON-RPC 2.0's symmetric design.
 - **Transport-Agnostic**: Abstract transport layer allows use of provided implementations or custom ones.
 - **Simple JSON Integration**: Uses [nlohmann/json](https://github.com/nlohmann/json) for easy JSON object interaction, requiring no learning curve.

--- a/examples/calculator_example/framed_pipe/client.cpp
+++ b/examples/calculator_example/framed_pipe/client.cpp
@@ -35,15 +35,17 @@ auto RunClient(asio::any_io_executor executor) -> asio::awaitable<void> {
   const int add_op1 = 10;
   const int add_op2 = 5;
   Json add_params = {{"a", add_op1}, {"b", add_op2}};
-  Json add_result = co_await client->SendMethodCall("add", add_params);
-  spdlog::info("Add result: {} + {} = {}", add_op1, add_op2, add_result.dump());
+  auto add_result = co_await client->SendMethodCall("add", add_params);
+  spdlog::info(
+      "Add result: {} + {} = {}", add_op1, add_op2, add_result.value().dump());
 
   // Example 2: Call "divide" method
   const int div_op1 = 10;
   const int div_op2 = 2;
   Json div_params = {{"a", div_op1}, {"b", div_op2}};
-  Json div_result = co_await client->SendMethodCall("divide", div_params);
-  spdlog::info("Div result: {} / {} = {}", div_op1, div_op2, div_result.dump());
+  auto div_result = co_await client->SendMethodCall("divide", div_params);
+  spdlog::info(
+      "Div result: {} / {} = {}", div_op1, div_op2, div_result.value().dump());
 
   // Step 3: Send notifications
   spdlog::info("Sending 'stop' notification to server");

--- a/examples/calculator_example/framed_pipe/client.cpp
+++ b/examples/calculator_example/framed_pipe/client.cpp
@@ -27,8 +27,9 @@ auto RunClient(asio::any_io_executor executor) -> asio::awaitable<void> {
   auto transport =
       std::make_unique<FramedPipeTransport>(executor, socket_path, false);
 
-  auto client =
+  auto client_result =
       co_await RpcEndpoint::CreateClient(executor, std::move(transport));
+  auto client = std::move(client_result.value());
 
   // Step 2: Make RPC method calls
   // Example 1: Call "add" method

--- a/examples/calculator_example/pipe/client.cpp
+++ b/examples/calculator_example/pipe/client.cpp
@@ -35,15 +35,17 @@ auto RunClient(asio::any_io_executor executor) -> asio::awaitable<void> {
   const int add_op1 = 10;
   const int add_op2 = 5;
   Json add_params = {{"a", add_op1}, {"b", add_op2}};
-  Json add_result = co_await client->SendMethodCall("add", add_params);
-  spdlog::info("Add result: {} + {} = {}", add_op1, add_op2, add_result.dump());
+  auto add_result = co_await client->SendMethodCall("add", add_params);
+  spdlog::info(
+      "Add result: {} + {} = {}", add_op1, add_op2, add_result.value().dump());
 
   // Example 2: Call "divide" method
   const int div_op1 = 10;
   const int div_op2 = 2;
   Json div_params = {{"a", div_op1}, {"b", div_op2}};
-  Json div_result = co_await client->SendMethodCall("divide", div_params);
-  spdlog::info("Div result: {} / {} = {}", div_op1, div_op2, div_result.dump());
+  auto div_result = co_await client->SendMethodCall("divide", div_params);
+  spdlog::info(
+      "Div result: {} / {} = {}", div_op1, div_op2, div_result.value().dump());
 
   // Step 3: Send notifications
   spdlog::info("Sending 'stop' notification to server");

--- a/examples/calculator_example/pipe/client.cpp
+++ b/examples/calculator_example/pipe/client.cpp
@@ -27,8 +27,9 @@ auto RunClient(asio::any_io_executor executor) -> asio::awaitable<void> {
   spdlog::info("Connecting to server on: {}", socket_path);
   auto transport = std::make_unique<PipeTransport>(executor, socket_path);
 
-  auto client =
+  auto client_result =
       co_await RpcEndpoint::CreateClient(executor, std::move(transport));
+  auto client = std::move(client_result.value());
 
   // Step 2: Make RPC method calls
   // Example 1: Call "add" method

--- a/examples/calculator_example/socket/client.cpp
+++ b/examples/calculator_example/socket/client.cpp
@@ -28,8 +28,9 @@ auto RunClient(asio::any_io_executor executor) -> asio::awaitable<void> {
 
   auto transport =
       std::make_unique<SocketTransport>(executor, host, port, false);
-  auto client =
+  auto client_result =
       co_await RpcEndpoint::CreateClient(executor, std::move(transport));
+  auto client = std::move(client_result.value());
 
   // Step 2: Make RPC method calls
   // Example 1: Call "add" method

--- a/examples/calculator_example/socket/client.cpp
+++ b/examples/calculator_example/socket/client.cpp
@@ -36,15 +36,17 @@ auto RunClient(asio::any_io_executor executor) -> asio::awaitable<void> {
   const int add_op1 = 10;
   const int add_op2 = 5;
   Json add_params = {{"a", add_op1}, {"b", add_op2}};
-  Json add_result = co_await client->SendMethodCall("add", add_params);
-  spdlog::info("Add result: {} + {} = {}", add_op1, add_op2, add_result.dump());
+  auto add_result = co_await client->SendMethodCall("add", add_params);
+  spdlog::info(
+      "Add result: {} + {} = {}", add_op1, add_op2, add_result.value().dump());
 
   // Example 2: Call "divide" method
   const int div_op1 = 10;
   const int div_op2 = 2;
   Json div_params = {{"a", div_op1}, {"b", div_op2}};
-  Json div_result = co_await client->SendMethodCall("divide", div_params);
-  spdlog::info("Div result: {} / {} = {}", div_op1, div_op2, div_result.dump());
+  auto div_result = co_await client->SendMethodCall("divide", div_params);
+  spdlog::info(
+      "Div result: {} / {} = {}", div_op1, div_op2, div_result.value().dump());
 
   // Step 3: Send notifications
   spdlog::info("Sending 'stop' notification to server");

--- a/examples/typed_calculator_example/client.cpp
+++ b/examples/typed_calculator_example/client.cpp
@@ -23,8 +23,9 @@ auto RunClient(asio::any_io_executor executor) -> asio::awaitable<void> {
   const std::string socket_path = "/tmp/typed_calculator_pipe";
   auto transport = std::make_unique<PipeTransport>(executor, socket_path);
 
-  auto client =
+  auto client_result =
       co_await RpcEndpoint::CreateClient(executor, std::move(transport));
+  auto client = std::move(client_result.value());
 
   // Call "add" method with typed params and result
   AddParams add_params{.a = 10.0, .b = 5.0};

--- a/examples/typed_calculator_example/client.cpp
+++ b/examples/typed_calculator_example/client.cpp
@@ -32,20 +32,22 @@ auto RunClient(asio::any_io_executor executor) -> asio::awaitable<void> {
   // Send the method call with typed params and receive typed result
   // Note how we specify the parameter and result types in the template
   // arguments
-  Result add_result =
+  auto add_result =
       co_await client->SendMethodCall<AddParams, Result>("add", add_params);
 
   // Access the result using the typed struct
   spdlog::info(
-      "Add result: {} + {} = {}", add_params.a, add_params.b, add_result.value);
+      "Add result: {} + {} = {}", add_params.a, add_params.b,
+      add_result.value().value);
 
   // Call "divide" method with typed params and result
   DivideParams div_params{.a = 10.0, .b = 2.0};
-  Result div_result = co_await client->SendMethodCall<DivideParams, Result>(
+  auto div_result = co_await client->SendMethodCall<DivideParams, Result>(
       "divide", div_params);
+
   spdlog::info(
       "Divide result: {} / {} = {}", div_params.a, div_params.b,
-      div_result.value);
+      div_result.value().value);
 
   // Send notification to shut down the server
   co_await client->SendNotification("stop");

--- a/include/jsonrpc/endpoint/dispatcher.hpp
+++ b/include/jsonrpc/endpoint/dispatcher.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <expected>
 #include <functional>
 #include <optional>
 #include <string>
@@ -8,7 +9,7 @@
 #include <asio.hpp>
 #include <nlohmann/json.hpp>
 
-#include "jsonrpc/endpoint/response.hpp"
+#include "jsonrpc/error/error.hpp"
 
 namespace jsonrpc::endpoint {
 
@@ -27,38 +28,29 @@ class Dispatcher {
   auto operator=(Dispatcher&&) -> Dispatcher& = delete;
   virtual ~Dispatcher() = default;
 
-  /// @brief Register a method call handler
   void RegisterMethodCall(
       const std::string& method, const MethodCallHandler& handler);
 
-  /// @brief Register a notification handler
   void RegisterNotification(
       const std::string& method, const NotificationHandler& handler);
 
-  /// @brief Dispatch a request
   auto DispatchRequest(std::string request)
       -> asio::awaitable<std::optional<std::string>>;
 
  private:
-  /// @brief Dispatch a single request
   auto DispatchSingleRequest(nlohmann::json request_json)
       -> asio::awaitable<std::optional<nlohmann::json>>;
 
-  /// @brief Dispatch a batch request
   auto DispatchBatchRequest(nlohmann::json request_json)
       -> asio::awaitable<std::optional<std::string>>;
 
-  /// @brief Validate a request
   static auto ValidateRequest(const nlohmann::json& request_json)
-      -> std::optional<Response>;
+      -> std::expected<void, error::RpcError>;
 
-  /// @brief Method call handlers
   std::unordered_map<std::string, MethodCallHandler> method_handlers_;
 
-  /// @brief Notification handlers
   std::unordered_map<std::string, NotificationHandler> notification_handlers_;
 
-  /// @brief Executor
   asio::any_io_executor executor_;
 };
 

--- a/include/jsonrpc/endpoint/dispatcher.hpp
+++ b/include/jsonrpc/endpoint/dispatcher.hpp
@@ -9,6 +9,8 @@
 #include <asio.hpp>
 #include <nlohmann/json.hpp>
 
+#include "jsonrpc/endpoint/request.hpp"
+#include "jsonrpc/endpoint/response.hpp"
 #include "jsonrpc/error/error.hpp"
 
 namespace jsonrpc::endpoint {
@@ -38,8 +40,8 @@ class Dispatcher {
       -> asio::awaitable<std::optional<std::string>>;
 
  private:
-  auto DispatchSingleRequest(nlohmann::json request_json)
-      -> asio::awaitable<std::optional<nlohmann::json>>;
+  auto DispatchSingleRequest(Request request)
+      -> asio::awaitable<std::optional<Response>>;
 
   auto DispatchBatchRequest(nlohmann::json request_json)
       -> asio::awaitable<std::optional<std::string>>;

--- a/include/jsonrpc/endpoint/dispatcher.hpp
+++ b/include/jsonrpc/endpoint/dispatcher.hpp
@@ -11,7 +11,6 @@
 
 #include "jsonrpc/endpoint/request.hpp"
 #include "jsonrpc/endpoint/response.hpp"
-#include "jsonrpc/error/error.hpp"
 
 namespace jsonrpc::endpoint {
 
@@ -45,9 +44,6 @@ class Dispatcher {
 
   auto DispatchBatchRequest(nlohmann::json request_json)
       -> asio::awaitable<std::optional<std::string>>;
-
-  static auto ValidateRequest(const nlohmann::json& request_json)
-      -> std::expected<void, error::RpcError>;
 
   std::unordered_map<std::string, MethodCallHandler> method_handlers_;
 

--- a/include/jsonrpc/endpoint/dispatcher.hpp
+++ b/include/jsonrpc/endpoint/dispatcher.hpp
@@ -42,8 +42,8 @@ class Dispatcher {
   auto DispatchSingleRequest(Request request)
       -> asio::awaitable<std::optional<Response>>;
 
-  auto DispatchBatchRequest(nlohmann::json request_json)
-      -> asio::awaitable<std::optional<std::string>>;
+  auto DispatchBatchRequest(std::vector<Request> requests)
+      -> asio::awaitable<std::vector<Response>>;
 
   std::unordered_map<std::string, MethodCallHandler> method_handlers_;
 

--- a/include/jsonrpc/endpoint/endpoint.hpp
+++ b/include/jsonrpc/endpoint/endpoint.hpp
@@ -32,7 +32,7 @@ class RpcEndpoint {
   static auto CreateClient(
       asio::any_io_executor executor,
       std::unique_ptr<transport::Transport> transport)
-      -> asio::awaitable<std::unique_ptr<RpcEndpoint>>;
+      -> asio::awaitable<std::expected<std::unique_ptr<RpcEndpoint>, RpcError>>;
 
   RpcEndpoint(const RpcEndpoint &) = delete;
   RpcEndpoint(RpcEndpoint &&) = delete;
@@ -43,9 +43,9 @@ class RpcEndpoint {
 
   auto Start() -> asio::awaitable<std::expected<void, RpcError>>;
 
-  auto WaitForShutdown() -> asio::awaitable<void>;
+  auto WaitForShutdown() -> asio::awaitable<std::expected<void, RpcError>>;
 
-  auto Shutdown() -> asio::awaitable<void>;
+  auto Shutdown() -> asio::awaitable<std::expected<void, RpcError>>;
 
   [[nodiscard]] auto IsRunning() const -> bool {
     return is_running_.load();
@@ -90,9 +90,11 @@ class RpcEndpoint {
 
   auto ProcessMessagesLoop() -> asio::awaitable<void>;
 
-  auto HandleMessage(std::string message) -> asio::awaitable<void>;
+  auto HandleMessage(std::string message)
+      -> asio::awaitable<std::expected<void, RpcError>>;
 
-  auto HandleResponse(Response response) -> asio::awaitable<void>;
+  auto HandleResponse(Response response)
+      -> asio::awaitable<std::expected<void, RpcError>>;
 
   auto GetNextRequestId() -> int64_t {
     return next_request_id_++;

--- a/include/jsonrpc/endpoint/endpoint.hpp
+++ b/include/jsonrpc/endpoint/endpoint.hpp
@@ -15,270 +15,106 @@
 #include "jsonrpc/endpoint/pending_request.hpp"
 #include "jsonrpc/endpoint/response.hpp"
 #include "jsonrpc/endpoint/typed_handlers.hpp"
-#include "jsonrpc/endpoint/types.hpp"
 #include "jsonrpc/transport/transport.hpp"
 
 namespace jsonrpc::endpoint {
 
+using jsonrpc::error::RpcError;
+
 using ErrorHandler = std::function<void(ErrorCode, const std::string &)>;
 
-/**
- * @brief RPC endpoint for sending and receiving JSON-RPC messages
- *
- * This class provides a JSON-RPC endpoint that can be used to call methods
- * on a remote endpoint and register method handlers for handling incoming
- * requests.
- */
 class RpcEndpoint {
  public:
-  /**
-   * @brief Construct a new RPC endpoint
-   *
-   * @param executor The executor to use
-   * @param transport The transport layer to use
-   */
   explicit RpcEndpoint(
       asio::any_io_executor executor,
       std::unique_ptr<transport::Transport> transport);
 
-  /**
-   * @brief Create a client endpoint asynchronously
-   *
-   * Creates and initializes a client endpoint. The returned awaitable resolves
-   * when the endpoint is fully initialized and ready to use.
-   *
-   * @param executor The executor to use
-   * @param transport The transport layer to use
-   * @return asio::awaitable<std::unique_ptr<RpcEndpoint>> Awaitable that
-   * resolves to the initialized client
-   */
   static auto CreateClient(
       asio::any_io_executor executor,
       std::unique_ptr<transport::Transport> transport)
       -> asio::awaitable<std::unique_ptr<RpcEndpoint>>;
 
-  // Delete copy and move constructors/assignments
   RpcEndpoint(const RpcEndpoint &) = delete;
-  auto operator=(const RpcEndpoint &) -> RpcEndpoint & = delete;
   RpcEndpoint(RpcEndpoint &&) = delete;
+  auto operator=(const RpcEndpoint &) -> RpcEndpoint & = delete;
   auto operator=(RpcEndpoint &&) -> RpcEndpoint & = delete;
 
-  /**
-   * @brief Destructor
-   */
   ~RpcEndpoint() = default;
 
-  /**
-   * @brief Start the endpoint
-   *
-   * Begins processing incoming messages and allows outgoing calls
-   *
-   * @return asio::awaitable<void>
-   */
   auto Start() -> asio::awaitable<void>;
 
-  /**
-   * @brief Wait for the endpoint to shut down
-   *
-   * This will poll periodically until is_running_ is false
-   *
-   * @return asio::awaitable<void>
-   */
   auto WaitForShutdown() -> asio::awaitable<void>;
 
-  /**
-   * @brief Shut down the endpoint
-   *
-   * Stops processing messages and cancels pending requests
-   *
-   * @return asio::awaitable<void>
-   */
   auto Shutdown() -> asio::awaitable<void>;
 
-  /**
-   * @brief Check if the endpoint is running
-   *
-   * @return bool True if running, false otherwise
-   */
   [[nodiscard]] auto IsRunning() const -> bool {
     return is_running_.load();
   }
 
-  /**
-   * @brief Call a method on the remote endpoint
-   *
-   * @param method The method name
-   * @param params The method parameters (optional)
-   * @return asio::awaitable<nlohmann::json> The result
-   */
   auto SendMethodCall(
       std::string method, std::optional<nlohmann::json> params = std::nullopt)
-      -> asio::awaitable<nlohmann::json>;
+      -> asio::awaitable<std::expected<nlohmann::json, RpcError>>;
 
-  /**
-   * @brief Call a method on the remote endpoint with typed params and result
-   *
-   * @tparam ParamsType The type of the parameters
-   * @tparam ResultType The type of the result
-   * @param method The method name
-   * @param params The method parameters
-   * @return asio::awaitable<ResultType> The typed result
-   */
   template <typename ParamsType, typename ResultType>
   auto SendMethodCall(std::string method, ParamsType params)
       -> asio::awaitable<ResultType>;
 
-  /**
-   * @brief Send a notification to the remote endpoint
-   *
-   * @param method The method name
-   * @param params The method parameters (optional)
-   * @return asio::awaitable<void>
-   */
   auto SendNotification(
       std::string method, std::optional<nlohmann::json> params = std::nullopt)
       -> asio::awaitable<void>;
 
-  /**
-   * @brief Send a notification to the remote endpoint with typed params
-   *
-   * @tparam ParamsType The type of the parameters
-   * @param method The method name
-   * @param params The method parameters
-   * @return asio::awaitable<void>
-   */
   template <typename ParamsType>
   auto SendNotification(std::string method, ParamsType params)
       -> asio::awaitable<void>;
 
-  /**
-   * @brief Register a method call handler
-   *
-   * @param method The method name
-   * @param handler The handler
-   */
   void RegisterMethodCall(
       std::string method, typename Dispatcher::MethodCallHandler handler);
 
-  /**
-   * @brief Register a typed method call handler
-   *
-   * @tparam ParamsType The type of the parameters
-   * @tparam ResultType The type of the result
-   * @param method The method name
-   * @param handler The handler
-   */
   template <typename ParamsType, typename ResultType>
   void RegisterMethodCall(
       std::string method,
       std::function<asio::awaitable<ResultType>(ParamsType)> handler);
 
-  /**
-   * @brief Register a notification handler
-   *
-   * @param method The method name
-   * @param handler The handler
-   */
   void RegisterNotification(
       std::string method, typename Dispatcher::NotificationHandler handler);
 
-  /**
-   * @brief Register a typed notification handler
-   *
-   * @tparam ParamsType The type of the parameters
-   * @param method The method name
-   * @param handler The handler
-   */
   template <typename ParamsType>
   void RegisterNotification(
       std::string method,
       std::function<asio::awaitable<void>(ParamsType)> handler);
 
-  /**
-   * @brief Check if there are pending requests
-   *
-   * @return bool True if there are pending requests, false otherwise
-   */
   [[nodiscard]] auto HasPendingRequests() const -> bool;
 
-  /**
-   * @brief Set the error handler
-   *
-   * @param handler The error handler
-   */
-  void SetErrorHandler(ErrorHandler handler);
-
-  /**
-   * @brief Report an error
-   *
-   * @param code The error code
-   * @param message The error message
-   */
-  void ReportError(ErrorCode code, const std::string &message);
-
  private:
-  /**
-   * @brief Start message processing
-   */
   void StartMessageProcessing();
 
-  /**
-   * @brief Process messages in a continuous loop
-   *
-   * @return asio::awaitable<void>
-   */
   auto ProcessMessagesLoop() -> asio::awaitable<void>;
 
-  /**
-   * @brief Handle a message
-   *
-   * @param message The message
-   */
   auto HandleMessage(std::string message) -> asio::awaitable<void>;
 
-  /**
-   * @brief Handle a response
-   *
-   * @param response The response
-   */
   auto HandleResponse(Response response) -> asio::awaitable<void>;
 
-  /**
-   * @brief Get the next request ID
-   *
-   * @return int64_t The next request ID
-   */
   auto GetNextRequestId() -> int64_t {
     return next_request_id_++;
   }
 
-  /// The executor to use for operations
   asio::any_io_executor executor_;
 
-  /// Transport layer
   std::unique_ptr<transport::Transport> transport_;
 
-  /// Dispatcher for handling requests
   Dispatcher dispatcher_;
 
-  /// Pending requests
   std::unordered_map<int64_t, std::shared_ptr<PendingRequest>>
       pending_requests_;
 
-  /// Running state flag
   std::atomic<bool> is_running_{false};
 
-  /// Error handler
   ErrorHandler error_handler_;
 
-  /// Strand for endpoint operations
   asio::strand<asio::any_io_executor> endpoint_strand_;
 
-  /// Next request ID
   std::atomic<int64_t> next_request_id_{0};
 };
-
-// Send method template implementations
 
 template <typename ParamsType, typename ResultType>
 auto RpcEndpoint::SendMethodCall(std::string method, ParamsType params)
@@ -288,10 +124,10 @@ auto RpcEndpoint::SendMethodCall(std::string method, ParamsType params)
     nlohmann::json json_params = params;
 
     // Call the method
-    nlohmann::json result = co_await SendMethodCall(method, json_params);
+    auto result = co_await SendMethodCall(method, json_params);
 
     // Convert result to typed result
-    ResultType typed_result = result.get<ResultType>();
+    ResultType typed_result = result.value();
 
     co_return typed_result;
   } catch (const nlohmann::json::exception &ex) {

--- a/include/jsonrpc/endpoint/endpoint.hpp
+++ b/include/jsonrpc/endpoint/endpoint.hpp
@@ -57,15 +57,15 @@ class RpcEndpoint {
 
   template <typename ParamsType, typename ResultType>
   auto SendMethodCall(std::string method, ParamsType params)
-      -> asio::awaitable<ResultType>;
+      -> asio::awaitable<std::expected<ResultType, RpcError>>;
 
   auto SendNotification(
       std::string method, std::optional<nlohmann::json> params = std::nullopt)
-      -> asio::awaitable<void>;
+      -> asio::awaitable<std::expected<void, RpcError>>;
 
   template <typename ParamsType>
   auto SendNotification(std::string method, ParamsType params)
-      -> asio::awaitable<void>;
+      -> asio::awaitable<std::expected<void, RpcError>>;
 
   void RegisterMethodCall(
       std::string method, typename Dispatcher::MethodCallHandler handler);
@@ -118,47 +118,46 @@ class RpcEndpoint {
 
 template <typename ParamsType, typename ResultType>
 auto RpcEndpoint::SendMethodCall(std::string method, ParamsType params)
-    -> asio::awaitable<ResultType> {
+    -> asio::awaitable<std::expected<ResultType, RpcError>> {
+  nlohmann::json json_params;
   try {
-    // Convert typed params to JSON
-    nlohmann::json json_params = params;
-
-    // Call the method
-    auto result = co_await SendMethodCall(method, json_params);
-
-    // Convert result to typed result
-    ResultType typed_result = result.value();
-
-    co_return typed_result;
+    json_params = params;
   } catch (const nlohmann::json::exception &ex) {
-    // Handle JSON conversion errors
-    // throw RpcError(
-    //     ErrorCode::kInvalidParams,
-    //     std::string("Result conversion error: ") + ex.what());
+    co_return error::CreateClientError(
+        "Failed to convert parameters to JSON: " + std::string(ex.what()));
+  }
+
+  auto result = co_await SendMethodCall(method, json_params);
+  if (!result) {
+    co_return std::unexpected(result.error());
+  }
+
+  try {
+    co_return result->template get<ResultType>();
+  } catch (const nlohmann::json::exception &ex) {
+    co_return error::CreateClientError(
+        "Failed to convert result: " + std::string(ex.what()));
   }
 }
 
 template <typename ParamsType>
 auto RpcEndpoint::SendNotification(std::string method, ParamsType params)
-    -> asio::awaitable<void> {
+    -> asio::awaitable<std::expected<void, RpcError>> {
+  nlohmann::json json_params;
   try {
-    // Convert typed params to JSON and send
-    nlohmann::json json_params = params;
-    co_await SendNotification(method, json_params);
+    json_params = params;
   } catch (const nlohmann::json::exception &ex) {
-    // Log the error but don't propagate it (notifications are
-    // fire-and-forget)
-    spdlog::error(
-        "Failed to convert parameters for notification method '{}': {}", method,
-        ex.what());
-  } catch (const std::exception &ex) {
-    // Log any other errors that might occur
-    spdlog::error(
-        "Unexpected error in notification method '{}': {}", method, ex.what());
+    co_return error::CreateClientError(
+        "Failed to convert notification parameters: " + std::string(ex.what()));
   }
-}
 
-// Register method template implementations
+  auto result = co_await SendNotification(method, json_params);
+  if (!result) {
+    co_return std::unexpected(result.error());
+  }
+
+  co_return {};
+}
 
 template <typename ParamsType, typename ResultType>
 void RpcEndpoint::RegisterMethodCall(

--- a/include/jsonrpc/endpoint/endpoint.hpp
+++ b/include/jsonrpc/endpoint/endpoint.hpp
@@ -296,9 +296,9 @@ auto RpcEndpoint::SendMethodCall(std::string method, ParamsType params)
     co_return typed_result;
   } catch (const nlohmann::json::exception &ex) {
     // Handle JSON conversion errors
-    throw RpcError(
-        ErrorCode::kInvalidParams,
-        std::string("Result conversion error: ") + ex.what());
+    // throw RpcError(
+    //     ErrorCode::kInvalidParams,
+    //     std::string("Result conversion error: ") + ex.what());
   }
 }
 

--- a/include/jsonrpc/endpoint/endpoint.hpp
+++ b/include/jsonrpc/endpoint/endpoint.hpp
@@ -88,7 +88,8 @@ class RpcEndpoint {
  private:
   void StartMessageProcessing();
 
-  auto ProcessMessagesLoop() -> asio::awaitable<void>;
+  auto ProcessMessagesLoop(asio::cancellation_slot slot)
+      -> asio::awaitable<void>;
 
   auto HandleMessage(std::string message)
       -> asio::awaitable<std::expected<void, RpcError>>;
@@ -116,6 +117,10 @@ class RpcEndpoint {
   asio::strand<asio::any_io_executor> endpoint_strand_;
 
   std::atomic<int64_t> next_request_id_{0};
+
+  asio::cancellation_signal cancel_signal_;
+
+  asio::awaitable<void> message_loop_;
 };
 
 template <typename ParamsType, typename ResultType>

--- a/include/jsonrpc/endpoint/endpoint.hpp
+++ b/include/jsonrpc/endpoint/endpoint.hpp
@@ -41,7 +41,7 @@ class RpcEndpoint {
 
   ~RpcEndpoint() = default;
 
-  auto Start() -> asio::awaitable<void>;
+  auto Start() -> asio::awaitable<std::expected<void, RpcError>>;
 
   auto WaitForShutdown() -> asio::awaitable<void>;
 

--- a/include/jsonrpc/endpoint/request.hpp
+++ b/include/jsonrpc/endpoint/request.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <expected>
 #include <functional>
 #include <optional>
 #include <string>
@@ -7,90 +8,43 @@
 #include <nlohmann/json.hpp>
 
 #include "jsonrpc/endpoint/types.hpp"
+#include "jsonrpc/error/error.hpp"
 
 namespace jsonrpc::endpoint {
 
-/**
- * @brief Represents a JSON-RPC request.
- *
- * This class handles the creation and management of JSON-RPC requests,
- * including both method calls and notifications. It supports both client-side
- * request creation and server-side request parsing.
- */
 class Request {
  public:
-  /**
-   * @brief Constructs a new Request object for client-side use.
-   *
-   * @param method The name of the method to be invoked.
-   * @param params Optional parameters to be passed with the request.
-   * @param id_generator Function to generate unique request IDs.
-   */
   Request(
       std::string method, std::optional<nlohmann::json> params,
       const std::function<RequestId()>& id_generator);
 
-  /**
-   * @brief Constructs a new Request object with a specific ID.
-   *
-   * @param method The name of the method to be invoked.
-   * @param params Optional parameters to be passed with the request.
-   * @param id The request ID.
-   */
   Request(
       std::string method, std::optional<nlohmann::json> params, RequestId id);
 
-  /**
-   * @brief Constructs a new notification Request object (no response expected).
-   *
-   * @param method The name of the method to be invoked.
-   * @param params Optional parameters to be passed with the request.
-   */
   explicit Request(
       std::string method, std::optional<nlohmann::json> params = std::nullopt);
 
-  /**
-   * @brief Creates a Request object from a JSON object for server-side use.
-   *
-   * @param json_obj The JSON object representing the request.
-   * @return A Request object.
-   * @throws std::invalid_argument if the JSON is not a valid request.
-   */
-  static auto FromJson(const nlohmann::json& json_obj) -> Request;
+  static auto FromJson(const nlohmann::json& json_obj)
+      -> std::expected<Request, error::RpcError>;
 
-  /**
-   * @brief Validates a JSON object as a request.
-   *
-   * @param json_obj The JSON object to validate.
-   * @return true if the JSON represents a valid request.
-   */
-  static auto ValidateJson(const nlohmann::json& json_obj) -> bool;
-
-  /// @brief Gets the method name.
   [[nodiscard]] auto GetMethod() const -> const std::string& {
     return method_;
   }
 
-  /// @brief Gets the parameters.
   [[nodiscard]] auto GetParams() const -> const std::optional<nlohmann::json>& {
     return params_;
   }
 
-  /// @brief Checks if the request is a notification (no response expected).
   [[nodiscard]] auto IsNotification() const -> bool {
     return is_notification_;
   }
 
-  /// @brief Checks if the request requires a response.
   [[nodiscard]] auto RequiresResponse() const -> bool;
 
-  /// @brief Returns the unique ID for the request.
   [[nodiscard]] auto GetId() const -> RequestId;
 
-  /// @brief Serializes the request to a JSON string.
   [[nodiscard]] auto Dump() const -> std::string;
 
-  /// @brief Converts the request to a JSON object.
   [[nodiscard]] auto ToJson() const -> nlohmann::json;
 
  private:

--- a/include/jsonrpc/endpoint/response.hpp
+++ b/include/jsonrpc/endpoint/response.hpp
@@ -2,7 +2,6 @@
 
 #include <expected>
 #include <optional>
-#include <string>
 
 #include <nlohmann/json.hpp>
 
@@ -12,6 +11,7 @@
 namespace jsonrpc::endpoint {
 
 using jsonrpc::error::ErrorCode;
+using jsonrpc::error::RpcError;
 
 class Response {
  public:
@@ -31,7 +31,7 @@ class Response {
       -> Response;
 
   static auto CreateLibError(
-      ErrorCode error_code, const std::optional<RequestId>& id = std::nullopt)
+      ErrorCode code, const std::optional<RequestId>& id = std::nullopt)
       -> Response;
 
   static auto CreateUserError(
@@ -46,12 +46,7 @@ class Response {
 
   [[nodiscard]] auto GetId() const -> std::optional<RequestId>;
 
-  [[nodiscard]] auto GetJson() const -> const nlohmann::json& {
-    return response_;
-  }
-
   [[nodiscard]] auto ToJson() const -> nlohmann::json;
-  [[nodiscard]] auto ToStr() const -> std::string;
 
  private:
   explicit Response(nlohmann::json response) : response_(std::move(response)) {
@@ -59,10 +54,6 @@ class Response {
 
   [[nodiscard]] auto ValidateResponse() const
       -> std::expected<void, error::RpcError>;
-
-  static auto CreateErrorResponse(
-      const std::string& message, int code, const std::optional<RequestId>& id)
-      -> nlohmann::json;
 
   nlohmann::json response_;
 };

--- a/include/jsonrpc/endpoint/response.hpp
+++ b/include/jsonrpc/endpoint/response.hpp
@@ -35,6 +35,10 @@ class Response {
       -> Response;
 
   static auto CreateError(
+      const RpcError& error, const std::optional<RequestId>& id = std::nullopt)
+      -> Response;
+
+  static auto CreateError(
       const nlohmann::json& error, const std::optional<RequestId>& id)
       -> Response;
 

--- a/include/jsonrpc/endpoint/response.hpp
+++ b/include/jsonrpc/endpoint/response.hpp
@@ -26,15 +26,15 @@ class Response {
   static auto FromJson(const nlohmann::json& json)
       -> std::expected<Response, error::RpcError>;
 
-  static auto CreateResult(
+  static auto CreateSuccess(
       const nlohmann::json& result, const std::optional<RequestId>& id)
       -> Response;
 
-  static auto CreateLibError(
+  static auto CreateError(
       ErrorCode code, const std::optional<RequestId>& id = std::nullopt)
       -> Response;
 
-  static auto CreateUserError(
+  static auto CreateError(
       const nlohmann::json& error, const std::optional<RequestId>& id)
       -> Response;
 

--- a/include/jsonrpc/endpoint/response.hpp
+++ b/include/jsonrpc/endpoint/response.hpp
@@ -63,3 +63,12 @@ class Response {
 };
 
 }  // namespace jsonrpc::endpoint
+
+namespace nlohmann {
+template <>
+struct adl_serializer<jsonrpc::endpoint::Response> {
+  static void to_json(json& j, const jsonrpc::endpoint::Response& r) {
+    j = r.ToJson();
+  }
+};
+}  // namespace nlohmann

--- a/include/jsonrpc/endpoint/response.hpp
+++ b/include/jsonrpc/endpoint/response.hpp
@@ -1,135 +1,70 @@
 #pragma once
 
+#include <expected>
 #include <optional>
 #include <string>
-#include <unordered_map>
 
 #include <nlohmann/json.hpp>
 
 #include "jsonrpc/endpoint/types.hpp"
+#include "jsonrpc/error/error.hpp"
 
 namespace jsonrpc::endpoint {
 
-/// @brief Enumeration for library error kinds.
-enum class LibErrorKind {
-  kParseError,
-  kInvalidRequest,
-  kMethodNotFound,
-  kInternalError,
-  kServerError
-};
+using jsonrpc::error::ErrorCode;
 
-using ErrorInfoMap =
-    std::unordered_map<LibErrorKind, std::pair<int, const char*>>;
-
-/// @brief Represents a JSON-RPC response.
 class Response {
  public:
-  Response() = delete;
-  Response(const Response&) = delete;
-  auto operator=(const Response&) -> Response& = delete;
-
-  Response(Response&& other) noexcept;
-  auto operator=(Response&& other) noexcept -> Response& = delete;
+  Response() = default;
+  Response(const Response&) = default;
+  Response(Response&& other) = default;
+  auto operator=(const Response&) -> Response& = default;
+  auto operator=(Response&& other) noexcept -> Response& = default;
 
   ~Response() = default;
 
-  /**
-   * @brief Creates a Response object from a JSON object.
-   * @param json The JSON object to parse.
-   * @return A Response object.
-   * @throws std::invalid_argument if the JSON is not a valid response.
-   */
-  static auto FromJson(const nlohmann::json& json) -> Response;
+  static auto FromJson(const nlohmann::json& json)
+      -> std::expected<Response, error::RpcError>;
 
-  /**
-   * @brief Constructs a Response object from a JSON object.
-   * @param response The JSON object representing the response.
-   */
-  explicit Response(nlohmann::json response);
-
-  /**
-   * @brief Creates a successful Response object.
-   * @param result The result of the method call.
-   * @param id The ID of the request.
-   * @return A Response object indicating success.
-   */
   static auto CreateResult(
       const nlohmann::json& result, const std::optional<RequestId>& id)
       -> Response;
 
-  /**
-   * @brief Creates a Response object for a library error.
-   * @param error_code The error code.
-   * @param id The ID of the request.
-   * @return A Response object indicating a library error.
-   */
   static auto CreateLibError(
       ErrorCode error_code, const std::optional<RequestId>& id = std::nullopt)
       -> Response;
 
-  /**
-   * @brief Creates a Response object for a user error.
-   * @param error The JSON object representing the error.
-   * @param id The ID of the request.
-   * @return A Response object indicating a user error.
-   */
   static auto CreateUserError(
       const nlohmann::json& error, const std::optional<RequestId>& id)
       -> Response;
 
-  /// @brief Checks if the response indicates success.
   [[nodiscard]] auto IsSuccess() const -> bool;
 
-  /// @brief Gets the result if this is a success response.
   [[nodiscard]] auto GetResult() const -> const nlohmann::json&;
 
-  /// @brief Gets the error if this is an error response.
   [[nodiscard]] auto GetError() const -> const nlohmann::json&;
 
-  /// @brief Gets the ID of the request this response is for.
   [[nodiscard]] auto GetId() const -> std::optional<RequestId>;
 
-  /**
-   * @brief Gets the underlying JSON object.
-   * @return The JSON representation of the response.
-   */
   [[nodiscard]] auto GetJson() const -> const nlohmann::json& {
     return response_;
   }
 
-  /**
-   * @brief Serializes the Response object to a JSON object.
-   * @return The JSON representation of the response.
-   */
   [[nodiscard]] auto ToJson() const -> nlohmann::json;
-
-  /**
-   * @brief Serializes the Response object to a string.
-   * @return The string representation of the response.
-   */
   [[nodiscard]] auto ToStr() const -> std::string;
 
  private:
-  /// @brief Validates the Response object.
-  void ValidateResponse() const;
+  explicit Response(nlohmann::json response) : response_(std::move(response)) {
+  }
 
-  /**
-   * @brief Creates a JSON object representing an error response.
-   * @param message The error message.
-   * @param code The error code.
-   * @param id The ID of the request.
-   * @return The JSON representation of the error response.
-   */
+  [[nodiscard]] auto ValidateResponse() const
+      -> std::expected<void, error::RpcError>;
+
   static auto CreateErrorResponse(
       const std::string& message, int code, const std::optional<RequestId>& id)
       -> nlohmann::json;
 
-  /// @brief The JSON object representing the response.
   nlohmann::json response_;
-
-  /// @brief Static data member for mapping error kinds to messages.
-  static const ErrorInfoMap kErrorInfoMap;
 };
 
 }  // namespace jsonrpc::endpoint

--- a/include/jsonrpc/endpoint/typed_handlers.hpp
+++ b/include/jsonrpc/endpoint/typed_handlers.hpp
@@ -54,13 +54,13 @@ class TypedMethodHandler {
       // Convert result back to JSON
       co_return nlohmann::json(result);
     } catch (const nlohmann::json::exception &ex) {
-      throw RpcError(
-          ErrorCode::kInvalidParams,
-          std::string("Parameter conversion error: ") + ex.what());
+      // throw RpcError(
+      //     ErrorCode::kInvalidParams,
+      //     std::string("Parameter conversion error: ") + ex.what());
     } catch (const std::exception &ex) {
-      throw RpcError(
-          ErrorCode::kInternalError,
-          std::string("Handler error: ") + ex.what());
+      // throw RpcError(
+      //     ErrorCode::kInternalError,
+      //     std::string("Handler error: ") + ex.what());
     }
   }
 };
@@ -86,13 +86,13 @@ class TypedNotificationHandler {
       // Call the typed handler
       co_await handler_(typed_params);
     } catch (const nlohmann::json::exception &ex) {
-      throw RpcError(
-          ErrorCode::kInvalidParams,
-          std::string("Parameter conversion error: ") + ex.what());
+      // throw RpcError(
+      //     ErrorCode::kInvalidParams,
+      //     std::string("Parameter conversion error: ") + ex.what());
     } catch (const std::exception &ex) {
-      throw RpcError(
-          ErrorCode::kInternalError,
-          std::string("Handler error: ") + ex.what());
+      // throw RpcError(
+      //     ErrorCode::kInternalError,
+      //     std::string("Handler error: ") + ex.what());
     }
   }
 };

--- a/include/jsonrpc/endpoint/types.hpp
+++ b/include/jsonrpc/endpoint/types.hpp
@@ -13,20 +13,20 @@ namespace jsonrpc::endpoint {
 /// @brief JSON-RPC 2.0 protocol version string
 constexpr std::string_view kJsonRpcVersion = "2.0";
 
-/// @brief Standard JSON-RPC 2.0 error codes
-enum class ErrorCode {
-  // Standard errors
-  kParseError = -32700,      ///< Invalid JSON was received
-  kInvalidRequest = -32600,  ///< The JSON sent is not a valid Request object
-  kMethodNotFound = -32601,  ///< The method does not exist / is not available
-  kInvalidParams = -32602,   ///< Invalid method parameter(s)
-  kInternalError = -32603,   ///< Internal JSON-RPC error
+// /// @brief Standard JSON-RPC 2.0 error codes
+// enum class ErrorCode {
+//   // Standard errors
+//   kParseError = -32700,      ///< Invalid JSON was received
+//   kInvalidRequest = -32600,  ///< The JSON sent is not a valid Request object
+//   kMethodNotFound = -32601,  ///< The method does not exist / is not
+//   available kInvalidParams = -32602,   ///< Invalid method parameter(s)
+//   kInternalError = -32603,   ///< Internal JSON-RPC error
 
-  // Implementation-defined server errors
-  kServerError = -32000,     ///< Generic server error
-  kTransportError = -32010,  ///< Transport-related error
-  kTimeoutError = -32001,    ///< Timeout error
-};
+//   // Implementation-defined server errors
+//   kServerError = -32000,     ///< Generic server error
+//   kTransportError = -32010,  ///< Transport-related error
+//   kTimeoutError = -32001,    ///< Timeout error
+// };
 
 /// Type for request IDs that can be either integer or string
 using RequestId = std::variant<int64_t, std::string>;
@@ -48,21 +48,21 @@ constexpr auto kDefaultRequestTimeout = std::chrono::milliseconds(30000);
 /// Default maximum batch size
 constexpr size_t kDefaultMaxBatchSize = 100;
 
-/**
- * @brief Exception class for RPC errors
- */
-class RpcError : public std::runtime_error {
- public:
-  RpcError(ErrorCode code, const std::string& message)
-      : std::runtime_error(message), code_(code) {
-  }
+// /**
+//  * @brief Exception class for RPC errors
+//  */
+// class RpcError : public std::runtime_error {
+//  public:
+//   RpcError(ErrorCode code, const std::string& message)
+//       : std::runtime_error(message), code_(code) {
+//   }
 
-  [[nodiscard]] auto GetCode() const -> ErrorCode {
-    return code_;
-  }
+//   [[nodiscard]] auto GetCode() const -> ErrorCode {
+//     return code_;
+//   }
 
- private:
-  ErrorCode code_;
-};
+//  private:
+//   ErrorCode code_;
+// };
 
 }  // namespace jsonrpc::endpoint

--- a/include/jsonrpc/endpoint/types.hpp
+++ b/include/jsonrpc/endpoint/types.hpp
@@ -10,59 +10,19 @@
 
 namespace jsonrpc::endpoint {
 
-/// @brief JSON-RPC 2.0 protocol version string
 constexpr std::string_view kJsonRpcVersion = "2.0";
 
-// /// @brief Standard JSON-RPC 2.0 error codes
-// enum class ErrorCode {
-//   // Standard errors
-//   kParseError = -32700,      ///< Invalid JSON was received
-//   kInvalidRequest = -32600,  ///< The JSON sent is not a valid Request object
-//   kMethodNotFound = -32601,  ///< The method does not exist / is not
-//   available kInvalidParams = -32602,   ///< Invalid method parameter(s)
-//   kInternalError = -32603,   ///< Internal JSON-RPC error
-
-//   // Implementation-defined server errors
-//   kServerError = -32000,     ///< Generic server error
-//   kTransportError = -32010,  ///< Transport-related error
-//   kTimeoutError = -32001,    ///< Timeout error
-// };
-
-/// Type for request IDs that can be either integer or string
 using RequestId = std::variant<int64_t, std::string>;
 
-/// Type for handling method calls - now synchronous for simplicity
 using MethodCallHandler =
     nlohmann::json(const std::optional<nlohmann::json>& params);
 
-/// Type for handling notifications - now synchronous for simplicity
 using NotificationHandler = void(const std::optional<nlohmann::json>& params);
 
-/// Type for a handler which can be either a method call handler or notification
-/// handler
 using Handler = std::variant<MethodCallHandler, NotificationHandler>;
 
-/// Default request timeout in milliseconds
 constexpr auto kDefaultRequestTimeout = std::chrono::milliseconds(30000);
 
-/// Default maximum batch size
 constexpr size_t kDefaultMaxBatchSize = 100;
-
-// /**
-//  * @brief Exception class for RPC errors
-//  */
-// class RpcError : public std::runtime_error {
-//  public:
-//   RpcError(ErrorCode code, const std::string& message)
-//       : std::runtime_error(message), code_(code) {
-//   }
-
-//   [[nodiscard]] auto GetCode() const -> ErrorCode {
-//     return code_;
-//   }
-
-//  private:
-//   ErrorCode code_;
-// };
 
 }  // namespace jsonrpc::endpoint

--- a/include/jsonrpc/error/error.hpp
+++ b/include/jsonrpc/error/error.hpp
@@ -21,10 +21,35 @@ enum class ErrorCode {
   kTimeoutError = -32001,
 };
 
+inline auto DefaultMessageFor(ErrorCode code) -> std::string_view {
+  switch (code) {
+    case ErrorCode::kParseError:
+      return "Parse error";
+    case ErrorCode::kInvalidRequest:
+      return "Invalid request";
+    case ErrorCode::kMethodNotFound:
+      return "Method not found";
+    case ErrorCode::kInvalidParams:
+      return "Invalid parameters";
+    case ErrorCode::kInternalError:
+      return "Internal error";
+    case ErrorCode::kServerError:
+      return "Server error";
+    case ErrorCode::kTransportError:
+      return "Transport error";
+    case ErrorCode::kTimeoutError:
+      return "Timeout error";
+  }
+  return "Unknown error";
+}
+
 // Base error type for all JSON-RPC errors
 struct RpcError {
-  RpcError(ErrorCode code, std::string message)
-      : code(code), message(std::move(message)) {
+  explicit RpcError(ErrorCode code, std::string message = "")
+      : code(code),
+        message(
+            message.empty() ? std::string(DefaultMessageFor(code))
+                            : std::move(message)) {
   }
   ErrorCode code;
   std::string message;
@@ -67,37 +92,6 @@ struct ServerError : RpcError {
       : RpcError(ErrorCode::kServerError, std::move(msg)) {
   }
 };
-
-// Factory functions to create errors
-[[nodiscard]] inline auto CreateProtocolError(
-    ErrorCode code, std::string message) -> RpcError {
-  return RpcError{code, std::move(message)};
-}
-
-[[nodiscard]] inline auto CreateParseError(std::string message = "Parse error")
-    -> RpcError {
-  return RpcError{ErrorCode::kParseError, std::move(message)};
-}
-
-[[nodiscard]] inline auto CreateInvalidRequest(
-    std::string message = "Invalid request") -> RpcError {
-  return RpcError{ErrorCode::kInvalidRequest, std::move(message)};
-}
-
-[[nodiscard]] inline auto CreateMethodNotFound(
-    std::string message = "Method not found") -> RpcError {
-  return RpcError{ErrorCode::kMethodNotFound, std::move(message)};
-}
-
-[[nodiscard]] inline auto CreateInvalidParams(
-    std::string message = "Invalid parameters") -> RpcError {
-  return RpcError{ErrorCode::kInvalidParams, std::move(message)};
-}
-
-[[nodiscard]] inline auto CreateInternalError(
-    std::string message = "Internal error") -> RpcError {
-  return RpcError{ErrorCode::kInternalError, std::move(message)};
-}
 
 [[nodiscard]] inline auto CreateTransportError(
     std::string message, std::error_code ec = {}) -> TransportError {

--- a/include/jsonrpc/error/error.hpp
+++ b/include/jsonrpc/error/error.hpp
@@ -1,0 +1,112 @@
+#pragma once
+
+#include <string>
+#include <system_error>
+
+#include <nlohmann/json.hpp>
+
+namespace jsonrpc::error {
+
+enum class ErrorCode {
+  // Standard errors
+  kParseError = -32700,
+  kInvalidRequest = -32600,
+  kMethodNotFound = -32601,
+  kInvalidParams = -32602,
+  kInternalError = -32603,
+
+  // Implementation-defined server errors
+  kServerError = -32000,
+  kTransportError = -32010,
+  kTimeoutError = -32001,
+};
+
+// Base error type for all JSON-RPC errors
+struct RpcError {
+  RpcError(ErrorCode code, std::string message)
+      : code(code), message(std::move(message)) {
+  }
+  ErrorCode code;
+  std::string message;
+
+  // Convert to JSON-RPC error object
+  [[nodiscard]] auto to_json() const -> nlohmann::json {
+    nlohmann::json json;
+    json["code"] = static_cast<int>(code);
+    json["message"] = message;
+    return json;
+  }
+};
+
+// Transport-related errors (network, IO failures, etc)
+struct TransportError : RpcError {
+  std::error_code system_error;
+
+  explicit TransportError(std::string msg, std::error_code ec = {})
+      : RpcError(ErrorCode::kTransportError, std::move(msg)), system_error(ec) {
+    if (system_error) {
+      message += ": " + system_error.message();
+    }
+  }
+
+  [[nodiscard]] auto to_json() const -> nlohmann::json {
+    nlohmann::json json = RpcError::to_json();
+    if (system_error) {
+      nlohmann::json data;
+      data["system_code"] = system_error.value();
+      data["system_message"] = system_error.message();
+      json["data"] = data;
+    }
+    return json;
+  }
+};
+
+// Server lifecycle errors (start/stop failures, resource issues)
+struct ServerError : RpcError {
+  explicit ServerError(std::string msg)
+      : RpcError(ErrorCode::kServerError, std::move(msg)) {
+  }
+};
+
+// Factory functions to create errors
+[[nodiscard]] inline auto CreateProtocolError(
+    ErrorCode code, std::string message) -> RpcError {
+  return RpcError{code, std::move(message)};
+}
+
+[[nodiscard]] inline auto CreateParseError(std::string message = "Parse error")
+    -> RpcError {
+  return RpcError{ErrorCode::kParseError, std::move(message)};
+}
+
+[[nodiscard]] inline auto CreateInvalidRequest(
+    std::string message = "Invalid request") -> RpcError {
+  return RpcError{ErrorCode::kInvalidRequest, std::move(message)};
+}
+
+[[nodiscard]] inline auto CreateMethodNotFound(
+    std::string message = "Method not found") -> RpcError {
+  return RpcError{ErrorCode::kMethodNotFound, std::move(message)};
+}
+
+[[nodiscard]] inline auto CreateInvalidParams(
+    std::string message = "Invalid parameters") -> RpcError {
+  return RpcError{ErrorCode::kInvalidParams, std::move(message)};
+}
+
+[[nodiscard]] inline auto CreateInternalError(
+    std::string message = "Internal error") -> RpcError {
+  return RpcError{ErrorCode::kInternalError, std::move(message)};
+}
+
+[[nodiscard]] inline auto CreateTransportError(
+    std::string message, std::error_code ec = {}) -> TransportError {
+  return TransportError(std::move(message), ec);
+}
+
+[[nodiscard]] inline auto CreateServerError(
+    std::string message = "Server error") -> ServerError {
+  return ServerError(std::move(message));
+}
+
+}  // namespace jsonrpc::error

--- a/include/jsonrpc/error/error.hpp
+++ b/include/jsonrpc/error/error.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <expected>
 #include <string>
 #include <system_error>
 
@@ -19,6 +20,9 @@ enum class ErrorCode {
   kServerError = -32000,
   kTransportError = -32010,
   kTimeoutError = -32001,
+
+  // Client errors
+  kClientError = -32099,
 };
 
 inline auto DefaultMessageFor(ErrorCode code) -> std::string_view {
@@ -39,6 +43,8 @@ inline auto DefaultMessageFor(ErrorCode code) -> std::string_view {
       return "Transport error";
     case ErrorCode::kTimeoutError:
       return "Timeout error";
+    case ErrorCode::kClientError:
+      return "Client error";
   }
   return "Unknown error";
 }
@@ -86,6 +92,13 @@ struct TransportError : RpcError {
   }
 };
 
+// Client errors
+struct ClientError : RpcError {
+  explicit ClientError(std::string msg)
+      : RpcError(ErrorCode::kClientError, std::move(msg)) {
+  }
+};
+
 // Server lifecycle errors (start/stop failures, resource issues)
 struct ServerError : RpcError {
   explicit ServerError(std::string msg)
@@ -94,13 +107,19 @@ struct ServerError : RpcError {
 };
 
 [[nodiscard]] inline auto CreateTransportError(
-    std::string message, std::error_code ec = {}) -> TransportError {
-  return TransportError(std::move(message), ec);
+    std::string message, std::error_code ec = {})
+    -> std::unexpected<TransportError> {
+  return std::unexpected(TransportError(std::move(message), ec));
 }
 
 [[nodiscard]] inline auto CreateServerError(
-    std::string message = "Server error") -> ServerError {
-  return ServerError(std::move(message));
+    std::string message = "Server error") -> std::unexpected<ServerError> {
+  return std::unexpected(ServerError(std::move(message)));
+}
+
+[[nodiscard]] inline auto CreateClientError(
+    std::string message = "Client error") -> std::unexpected<ClientError> {
+  return std::unexpected(ClientError(std::move(message)));
 }
 
 }  // namespace jsonrpc::error

--- a/include/jsonrpc/transport/framed_pipe_transport.hpp
+++ b/include/jsonrpc/transport/framed_pipe_transport.hpp
@@ -9,20 +9,8 @@
 
 namespace jsonrpc::transport {
 
-/**
- * @brief Transport layer using Asio Unix domain sockets for JSON-RPC
- * communication with framing.
- */
 class FramedPipeTransport : public PipeTransport {
  public:
-  /**
-   * @brief Constructs a FramedPipeTransport.
-   *
-   * @param executor The executor to use for async operations.
-   * @param socket_path The path to the Unix domain socket.
-   * @param is_server True if the transport acts as a server; false if it acts
-   * as a client.
-   */
   FramedPipeTransport(
       asio::any_io_executor executor, const std::string& socket_path,
       bool is_server);

--- a/include/jsonrpc/transport/framed_pipe_transport.hpp
+++ b/include/jsonrpc/transport/framed_pipe_transport.hpp
@@ -18,7 +18,8 @@ class FramedPipeTransport : public PipeTransport {
   auto SendMessage(std::string message)
       -> asio::awaitable<std::expected<void, error::RpcError>> override;
 
-  auto ReceiveMessage() -> asio::awaitable<std::string> override;
+  auto ReceiveMessage()
+      -> asio::awaitable<std::expected<std::string, error::RpcError>> override;
 
  private:
   std::string read_buffer_;

--- a/include/jsonrpc/transport/framed_pipe_transport.hpp
+++ b/include/jsonrpc/transport/framed_pipe_transport.hpp
@@ -15,7 +15,8 @@ class FramedPipeTransport : public PipeTransport {
       asio::any_io_executor executor, const std::string& socket_path,
       bool is_server);
 
-  auto SendMessage(std::string message) -> asio::awaitable<void> override;
+  auto SendMessage(std::string message)
+      -> asio::awaitable<std::expected<void, error::RpcError>> override;
 
   auto ReceiveMessage() -> asio::awaitable<std::string> override;
 

--- a/include/jsonrpc/transport/pipe_transport.hpp
+++ b/include/jsonrpc/transport/pipe_transport.hpp
@@ -38,7 +38,8 @@ class PipeTransport : public Transport {
   auto SendMessage(std::string message)
       -> asio::awaitable<std::expected<void, error::RpcError>> override;
 
-  auto ReceiveMessage() -> asio::awaitable<std::string> override;
+  auto ReceiveMessage()
+      -> asio::awaitable<std::expected<std::string, error::RpcError>> override;
 
  protected:
   auto GetSocket() -> asio::local::stream_protocol::socket&;

--- a/include/jsonrpc/transport/pipe_transport.hpp
+++ b/include/jsonrpc/transport/pipe_transport.hpp
@@ -50,7 +50,7 @@ class PipeTransport : public Transport {
 
  private:
   asio::local::stream_protocol::socket socket_;
-  std::shared_ptr<asio::local::stream_protocol::acceptor> acceptor_;
+  std::unique_ptr<asio::local::stream_protocol::acceptor> acceptor_;
   std::string socket_path_;
   bool is_server_;
   std::atomic<bool> is_closed_{false};

--- a/include/jsonrpc/transport/pipe_transport.hpp
+++ b/include/jsonrpc/transport/pipe_transport.hpp
@@ -27,20 +27,21 @@ class PipeTransport : public Transport {
   PipeTransport(PipeTransport&&) = delete;
   auto operator=(PipeTransport&&) -> PipeTransport& = delete;
 
-  auto GetSocket() -> asio::local::stream_protocol::socket&;
-
   auto Start()
       -> asio::awaitable<std::expected<void, error::RpcError>> override;
+
+  auto Close()
+      -> asio::awaitable<std::expected<void, error::RpcError>> override;
+
+  void CloseNow() override;
 
   auto SendMessage(std::string message) -> asio::awaitable<void> override;
 
   auto ReceiveMessage() -> asio::awaitable<std::string> override;
 
-  auto Close() -> asio::awaitable<void> override;
-
-  void CloseNow() override;
-
  protected:
+  auto GetSocket() -> asio::local::stream_protocol::socket&;
+
   auto RemoveExistingSocketFile() -> std::expected<void, error::RpcError>;
 
   auto Connect() -> asio::awaitable<std::expected<void, error::RpcError>>;

--- a/include/jsonrpc/transport/pipe_transport.hpp
+++ b/include/jsonrpc/transport/pipe_transport.hpp
@@ -2,62 +2,35 @@
 
 #include <array>
 #include <atomic>
+#include <expected>
 #include <string>
 
 #include <asio.hpp>
 #include <asio/local/stream_protocol.hpp>
 
+#include "jsonrpc/error/error.hpp"
 #include "jsonrpc/transport/transport.hpp"
 
 namespace jsonrpc::transport {
 
-/**
- * @brief Unix domain socket transport implementation.
- *
- * This transport uses Unix domain sockets to communicate between endpoints.
- */
 class PipeTransport : public Transport {
  public:
-  /**
-   * @brief Constructs a new Pipe Transport object.
-   *
-   * @param executor The executor to use.
-   * @param socket_path The path to the socket file.
-   * @param is_server Whether this endpoint is a server (true) or client
-   * (false).
-   */
   explicit PipeTransport(
       asio::any_io_executor executor, std::string socket_path,
       bool is_server = false);
 
-  /**
-   * @brief Destroys the Pipe Transport object.
-   */
   ~PipeTransport() override;
 
-  // Delete copy and move constructors/assignments
   PipeTransport(const PipeTransport&) = delete;
   auto operator=(const PipeTransport&) -> PipeTransport& = delete;
 
   PipeTransport(PipeTransport&&) = delete;
   auto operator=(PipeTransport&&) -> PipeTransport& = delete;
 
-  /**
-   * @brief Gets the underlying socket.
-   *
-   * @return Reference to the socket
-   */
   auto GetSocket() -> asio::local::stream_protocol::socket&;
 
-  /**
-   * @brief Start the transport
-   *
-   * For server: Sets up the socket and begins listening
-   * For client: Connects to the server
-   *
-   * @return asio::awaitable<void>
-   */
-  auto Start() -> asio::awaitable<void> override;
+  auto Start()
+      -> asio::awaitable<std::expected<void, error::RpcError>> override;
 
   auto SendMessage(std::string message) -> asio::awaitable<void> override;
 
@@ -65,36 +38,14 @@ class PipeTransport : public Transport {
 
   auto Close() -> asio::awaitable<void> override;
 
-  /**
-   * @brief Close the transport synchronously.
-   *
-   * Safe to use in destructors. Immediately cancels operations and closes
-   * socket connections.
-   */
   void CloseNow() override;
 
  protected:
-  /**
-   * @brief Removes the socket file if it exists.
-   *
-   * This is called before binding to ensure that the socket file doesn't
-   * already exist.
-   */
-  void RemoveExistingSocketFile();
+  auto RemoveExistingSocketFile() -> std::expected<void, error::RpcError>;
 
-  /**
-   * @brief Connects to a server.
-   *
-   * @return asio::awaitable<void>
-   */
-  auto Connect() -> asio::awaitable<void>;
+  auto Connect() -> asio::awaitable<std::expected<void, error::RpcError>>;
 
-  /**
-   * @brief Binds to a socket and starts listening.
-   *
-   * @return asio::awaitable<void>
-   */
-  auto BindAndListen() -> asio::awaitable<void>;
+  auto BindAndListen() -> asio::awaitable<std::expected<void, error::RpcError>>;
 
  private:
   asio::local::stream_protocol::socket socket_;

--- a/include/jsonrpc/transport/pipe_transport.hpp
+++ b/include/jsonrpc/transport/pipe_transport.hpp
@@ -35,7 +35,8 @@ class PipeTransport : public Transport {
 
   void CloseNow() override;
 
-  auto SendMessage(std::string message) -> asio::awaitable<void> override;
+  auto SendMessage(std::string message)
+      -> asio::awaitable<std::expected<void, error::RpcError>> override;
 
   auto ReceiveMessage() -> asio::awaitable<std::string> override;
 

--- a/include/jsonrpc/transport/socket_transport.hpp
+++ b/include/jsonrpc/transport/socket_transport.hpp
@@ -35,7 +35,8 @@ class SocketTransport : public Transport {
   auto SendMessage(std::string message)
       -> asio::awaitable<std::expected<void, error::RpcError>> override;
 
-  auto ReceiveMessage() -> asio::awaitable<std::string> override;
+  auto ReceiveMessage()
+      -> asio::awaitable<std::expected<std::string, error::RpcError>> override;
 
  private:
   auto GetSocket() -> asio::ip::tcp::socket&;

--- a/include/jsonrpc/transport/socket_transport.hpp
+++ b/include/jsonrpc/transport/socket_transport.hpp
@@ -44,6 +44,7 @@ class SocketTransport : public Transport {
   auto BindAndListen() -> asio::awaitable<std::expected<void, error::RpcError>>;
 
   asio::ip::tcp::socket socket_;
+  std::unique_ptr<asio::ip::tcp::acceptor> acceptor_;
   std::string address_;
   uint16_t port_;
   bool is_server_;

--- a/include/jsonrpc/transport/socket_transport.hpp
+++ b/include/jsonrpc/transport/socket_transport.hpp
@@ -27,21 +27,21 @@ class SocketTransport : public Transport {
   auto Start()
       -> asio::awaitable<std::expected<void, error::RpcError>> override;
 
+  auto Close()
+      -> asio::awaitable<std::expected<void, error::RpcError>> override;
+
+  auto CloseNow() -> void override;
+
   auto SendMessage(std::string message) -> asio::awaitable<void> override;
 
   auto ReceiveMessage() -> asio::awaitable<std::string> override;
 
-  auto Close()
-      -> asio::awaitable<std::expected<void, error::RpcError>> override;
-
-  void CloseNow() override;
-
+ private:
   auto GetSocket() -> asio::ip::tcp::socket&;
 
- private:
-  auto Connect() -> asio::awaitable<void>;
+  auto Connect() -> asio::awaitable<std::expected<void, error::RpcError>>;
 
-  auto BindAndListen() -> asio::awaitable<void>;
+  auto BindAndListen() -> asio::awaitable<std::expected<void, error::RpcError>>;
 
   asio::ip::tcp::socket socket_;
   std::string address_;

--- a/include/jsonrpc/transport/socket_transport.hpp
+++ b/include/jsonrpc/transport/socket_transport.hpp
@@ -32,7 +32,8 @@ class SocketTransport : public Transport {
 
   auto CloseNow() -> void override;
 
-  auto SendMessage(std::string message) -> asio::awaitable<void> override;
+  auto SendMessage(std::string message)
+      -> asio::awaitable<std::expected<void, error::RpcError>> override;
 
   auto ReceiveMessage() -> asio::awaitable<std::string> override;
 

--- a/include/jsonrpc/transport/socket_transport.hpp
+++ b/include/jsonrpc/transport/socket_transport.hpp
@@ -10,29 +10,12 @@
 
 namespace jsonrpc::transport {
 
-/**
- * @brief Transport implementation using TCP/IP sockets.
- *
- * This class provides transport functionality over TCP/IP sockets,
- * supporting both client and server modes for communication over a network.
- */
 class SocketTransport : public Transport {
  public:
-  /**
-   * @brief Constructs a SocketTransport.
-   * @param executor The executor to use for async operations.
-   * @param address The host address (IP or domain name).
-   * @param port The port number.
-   * @param is_server True if the transport acts as a server; false if it acts
-   * as a client.
-   */
   SocketTransport(
       asio::any_io_executor executor, std::string address, uint16_t port,
       bool is_server);
 
-  /**
-   * @brief Destroys the Socket Transport object.
-   */
   ~SocketTransport() override;
 
   SocketTransport(const SocketTransport&) = delete;
@@ -41,48 +24,22 @@ class SocketTransport : public Transport {
   SocketTransport(SocketTransport&&) = delete;
   auto operator=(SocketTransport&&) -> SocketTransport& = delete;
 
-  /**
-   * @brief Start the transport
-   *
-   * For server: Binds to the specified address/port and starts listening
-   * For client: Connects to the specified server address/port
-   *
-   * @return asio::awaitable<void>
-   */
-  auto Start() -> asio::awaitable<void> override;
+  auto Start()
+      -> asio::awaitable<std::expected<void, error::RpcError>> override;
 
-  // Implement pure virtual functions from Transport
   auto SendMessage(std::string message) -> asio::awaitable<void> override;
 
   auto ReceiveMessage() -> asio::awaitable<std::string> override;
 
   auto Close() -> asio::awaitable<void> override;
 
-  /**
-   * @brief Close the transport synchronously.
-   *
-   * Safe to use in destructors. Immediately cancels operations and closes
-   * socket connections.
-   */
   void CloseNow() override;
 
-  /**
-   * @brief Gets access to the underlying socket.
-   * @return A reference to the socket.
-   */
   auto GetSocket() -> asio::ip::tcp::socket&;
 
  private:
-  /**
-   * @brief Connects to a remote endpoint if in client mode.
-   * @return Awaitable that completes when connected.
-   */
   auto Connect() -> asio::awaitable<void>;
 
-  /**
-   * @brief Binds to a local endpoint and listens if in server mode.
-   * @return Awaitable that completes when a client connects.
-   */
   auto BindAndListen() -> asio::awaitable<void>;
 
   asio::ip::tcp::socket socket_;

--- a/include/jsonrpc/transport/socket_transport.hpp
+++ b/include/jsonrpc/transport/socket_transport.hpp
@@ -31,7 +31,8 @@ class SocketTransport : public Transport {
 
   auto ReceiveMessage() -> asio::awaitable<std::string> override;
 
-  auto Close() -> asio::awaitable<void> override;
+  auto Close()
+      -> asio::awaitable<std::expected<void, error::RpcError>> override;
 
   void CloseNow() override;
 

--- a/include/jsonrpc/transport/transport.hpp
+++ b/include/jsonrpc/transport/transport.hpp
@@ -26,39 +26,19 @@ class Transport {
   virtual auto Start()
       -> asio::awaitable<std::expected<void, error::RpcError>> = 0;
 
-  /// @brief Sends a message over the transport.
   virtual auto SendMessage(std::string message) -> asio::awaitable<void> = 0;
 
-  /// @brief Receives a message over the transport.
   virtual auto ReceiveMessage() -> asio::awaitable<std::string> = 0;
 
-  /**
-   * @brief Closes the transport asynchronously.
-   *
-   * This is the asynchronous version of close, which should be used during
-   * normal operation.
-   *
-   * @return asio::awaitable<void>
-   */
-  virtual auto Close() -> asio::awaitable<void> = 0;
+  virtual auto Close()
+      -> asio::awaitable<std::expected<void, error::RpcError>> = 0;
 
-  /**
-   * @brief Closes the transport synchronously.
-   *
-   * This is a synchronous version of Close() that's safe to use in destructors.
-   * Implementations should ensure this method doesn't throw exceptions.
-   */
   virtual void CloseNow() = 0;
 
-  /// @brief Gets the executor for this transport.
   [[nodiscard]] auto GetExecutor() const -> asio::any_io_executor {
     return executor_;
   }
 
-  /**
-   * @brief Get the strand used for synchronization.
-   * @return Reference to the strand
-   */
   [[nodiscard]] auto GetStrand() -> asio::strand<asio::any_io_executor> & {
     return strand_;
   }

--- a/include/jsonrpc/transport/transport.hpp
+++ b/include/jsonrpc/transport/transport.hpp
@@ -34,7 +34,8 @@ class Transport {
   virtual auto SendMessage(std::string message)
       -> asio::awaitable<std::expected<void, error::RpcError>> = 0;
 
-  virtual auto ReceiveMessage() -> asio::awaitable<std::string> = 0;
+  virtual auto ReceiveMessage()
+      -> asio::awaitable<std::expected<std::string, error::RpcError>> = 0;
 
   [[nodiscard]] auto GetExecutor() const -> asio::any_io_executor {
     return executor_;

--- a/include/jsonrpc/transport/transport.hpp
+++ b/include/jsonrpc/transport/transport.hpp
@@ -1,21 +1,16 @@
 #pragma once
 
+#include <expected>
 #include <string>
 
 #include <asio.hpp>
 
+#include "jsonrpc/error/error.hpp"
+
 namespace jsonrpc::transport {
 
-/**
- * @brief Abstract base class for all transport implementations.
- */
 class Transport {
  public:
-  /**
-   * @brief Constructs a Transport with the given executor.
-   *
-   * @param executor The executor to use for asynchronous operations.
-   */
   explicit Transport(asio::any_io_executor executor)
       : executor_(std::move(executor)), strand_(asio::make_strand(executor_)) {
   }
@@ -28,16 +23,8 @@ class Transport {
 
   virtual ~Transport() = default;
 
-  /**
-   * @brief Starts the transport.
-   *
-   * This initializes connections and prepares the transport for communication.
-   * For server transports, this typically involves binding and listening.
-   * For client transports, this involves connecting to the server.
-   *
-   * @return asio::awaitable<void>
-   */
-  virtual auto Start() -> asio::awaitable<void> = 0;
+  virtual auto Start()
+      -> asio::awaitable<std::expected<void, error::RpcError>> = 0;
 
   /// @brief Sends a message over the transport.
   virtual auto SendMessage(std::string message) -> asio::awaitable<void> = 0;

--- a/include/jsonrpc/transport/transport.hpp
+++ b/include/jsonrpc/transport/transport.hpp
@@ -31,7 +31,8 @@ class Transport {
 
   virtual auto CloseNow() -> void = 0;
 
-  virtual auto SendMessage(std::string message) -> asio::awaitable<void> = 0;
+  virtual auto SendMessage(std::string message)
+      -> asio::awaitable<std::expected<void, error::RpcError>> = 0;
 
   virtual auto ReceiveMessage() -> asio::awaitable<std::string> = 0;
 

--- a/include/jsonrpc/transport/transport.hpp
+++ b/include/jsonrpc/transport/transport.hpp
@@ -26,14 +26,14 @@ class Transport {
   virtual auto Start()
       -> asio::awaitable<std::expected<void, error::RpcError>> = 0;
 
-  virtual auto SendMessage(std::string message) -> asio::awaitable<void> = 0;
-
-  virtual auto ReceiveMessage() -> asio::awaitable<std::string> = 0;
-
   virtual auto Close()
       -> asio::awaitable<std::expected<void, error::RpcError>> = 0;
 
-  virtual void CloseNow() = 0;
+  virtual auto CloseNow() -> void = 0;
+
+  virtual auto SendMessage(std::string message) -> asio::awaitable<void> = 0;
+
+  virtual auto ReceiveMessage() -> asio::awaitable<std::string> = 0;
 
   [[nodiscard]] auto GetExecutor() const -> asio::any_io_executor {
     return executor_;

--- a/src/endpoint/dispatcher.cpp
+++ b/src/endpoint/dispatcher.cpp
@@ -136,30 +136,4 @@ auto Dispatcher::DispatchBatchRequest(nlohmann::json request_json)
   co_return nlohmann::json(responses).dump();
 }
 
-auto Dispatcher::ValidateRequest(const nlohmann::json& request_json)
-    -> std::expected<void, error::RpcError> {
-  if (!request_json.contains("method")) {
-    return std::unexpected(
-        error::RpcError{ErrorCode::kInvalidRequest, "Method is required"});
-  }
-
-  const auto& method = request_json["method"];
-  if (!method.is_string()) {
-    return std::unexpected(
-        error::RpcError{ErrorCode::kInvalidRequest, "Method must be a string"});
-  }
-
-  // For params, if present, must be object or array
-  if (request_json.contains("params")) {
-    const auto& params = request_json["params"];
-    if (!params.is_object() && !params.is_array() && !params.is_null()) {
-      return std::unexpected(error::RpcError{
-          ErrorCode::kInvalidRequest, "Params must be object or array"});
-    }
-  }
-
-  // Request is valid
-  return {};
-}
-
 }  // namespace jsonrpc::endpoint

--- a/src/endpoint/dispatcher.cpp
+++ b/src/endpoint/dispatcher.cpp
@@ -25,22 +25,18 @@ auto Dispatcher::DispatchRequest(std::string request)
   try {
     request_json = nlohmann::json::parse(request);
   } catch (const nlohmann::json::parse_error& e) {
-    co_return Response::CreateLibError(ErrorCode::kParseError).ToJson().dump();
+    co_return Response::CreateError(ErrorCode::kParseError).ToJson().dump();
   }
 
   // Now validate the request
   if (request_json.is_object() && !Request::ValidateJson(request_json)) {
     // This is an invalid request error
-    co_return Response::CreateLibError(ErrorCode::kInvalidRequest)
-        .ToJson()
-        .dump();
+    co_return Response::CreateError(ErrorCode::kInvalidRequest).ToJson().dump();
   }
 
   // Handle empty batch requests
   if (request_json.is_array() && request_json.empty()) {
-    co_return Response::CreateLibError(ErrorCode::kInvalidRequest)
-        .ToJson()
-        .dump();
+    co_return Response::CreateError(ErrorCode::kInvalidRequest).ToJson().dump();
   }
 
   if (request_json.is_array()) {
@@ -86,20 +82,17 @@ auto Dispatcher::DispatchSingleRequest(nlohmann::json request_json)
           return handler(params);
         },
         asio::use_awaitable);
-    co_return Response::CreateResult(result, request.GetId()).ToJson();
+    co_return Response::CreateSuccess(result, request.GetId()).ToJson();
   }
 
-  co_return Response::CreateLibError(
-      ErrorCode::kMethodNotFound, request.GetId())
+  co_return Response::CreateError(ErrorCode::kMethodNotFound, request.GetId())
       .ToJson();
 }
 
 auto Dispatcher::DispatchBatchRequest(nlohmann::json request_json)
     -> asio::awaitable<std::optional<std::string>> {
   if (request_json.empty()) {
-    co_return Response::CreateLibError(ErrorCode::kInvalidRequest)
-        .ToJson()
-        .dump();
+    co_return Response::CreateError(ErrorCode::kInvalidRequest).ToJson().dump();
   }
 
   std::vector<asio::awaitable<std::optional<nlohmann::json>>> pending_requests;
@@ -112,9 +105,9 @@ auto Dispatcher::DispatchBatchRequest(nlohmann::json request_json)
       // For invalid requests, create an immediate error response as a coroutine
       pending_requests.push_back(
           []() -> asio::awaitable<std::optional<nlohmann::json>> {
-            auto error_json = Response::CreateLibError(
-                                  ErrorCode::kInvalidRequest, std::nullopt)
-                                  .ToJson();
+            auto error_json =
+                Response::CreateError(ErrorCode::kInvalidRequest, std::nullopt)
+                    .ToJson();
             co_return error_json;
           }());
     } else {
@@ -142,13 +135,13 @@ auto Dispatcher::DispatchBatchRequest(nlohmann::json request_json)
 auto Dispatcher::ValidateRequest(const nlohmann::json& request_json)
     -> std::optional<Response> {
   if (!request_json.contains("method")) {
-    return Response::CreateLibError(
+    return Response::CreateError(
         ErrorCode::kInvalidRequest, "Method is required");
   }
 
   const auto& method = request_json["method"];
   if (!method.is_string()) {
-    return Response::CreateLibError(
+    return Response::CreateError(
         ErrorCode::kInvalidRequest, "Method must be a string");
   }
 
@@ -156,7 +149,7 @@ auto Dispatcher::ValidateRequest(const nlohmann::json& request_json)
   if (request_json.contains("params")) {
     const auto& params = request_json["params"];
     if (!params.is_object() && !params.is_array() && !params.is_null()) {
-      return Response::CreateLibError(
+      return Response::CreateError(
           ErrorCode::kInvalidRequest, "Params must be object or array");
     }
   }

--- a/src/endpoint/dispatcher.cpp
+++ b/src/endpoint/dispatcher.cpp
@@ -33,10 +33,11 @@ auto Dispatcher::DispatchRequest(std::string request)
     co_return Response::CreateError(ErrorCode::kParseError).ToJson().dump();
   }
 
-  // Now validate the request
-  if (request_json.is_object() && !Request::ValidateJson(request_json)) {
-    // This is an invalid request error
-    co_return Response::CreateError(ErrorCode::kInvalidRequest).ToJson().dump();
+  if (request_json.is_object()) {
+    auto request_obj = Request::FromJson(request_json);
+    if (!request_obj.has_value()) {
+      co_return Response::CreateError(request_obj.error()).ToJson().dump();
+    }
   }
 
   // Handle empty batch requests
@@ -63,15 +64,19 @@ auto Dispatcher::DispatchSingleRequest(nlohmann::json request_json)
     co_return Response::CreateError(result.error()).ToJson().dump();
   }
 
-  Request request = Request::FromJson(request_json);
-  auto method = request.GetMethod();
+  auto request = Request::FromJson(request_json);
+  if (!request) {
+    co_return Response::CreateError(request.error()).ToJson().dump();
+  }
 
-  if (request.IsNotification()) {
+  auto method = request->GetMethod();
+
+  if (request->IsNotification()) {
     auto it = notification_handlers_.find(method);
     if (it != notification_handlers_.end()) {
       co_spawn(
           executor_,
-          [handler = it->second, params = request.GetParams()] {
+          [handler = it->second, params = request->GetParams()] {
             return handler(params);
           },
           asio::detached);
@@ -83,14 +88,14 @@ auto Dispatcher::DispatchSingleRequest(nlohmann::json request_json)
   if (it != method_handlers_.end()) {
     auto result = co_await asio::co_spawn(
         executor_,
-        [handler = it->second, params = request.GetParams()] {
+        [handler = it->second, params = request->GetParams()] {
           return handler(params);
         },
         asio::use_awaitable);
-    co_return Response::CreateSuccess(result, request.GetId()).ToJson();
+    co_return Response::CreateSuccess(result, request->GetId()).ToJson();
   }
 
-  co_return Response::CreateError(ErrorCode::kMethodNotFound, request.GetId())
+  co_return Response::CreateError(ErrorCode::kMethodNotFound, request->GetId())
       .ToJson();
 }
 
@@ -106,7 +111,7 @@ auto Dispatcher::DispatchBatchRequest(nlohmann::json request_json)
   // Queue all requests in parallel
   for (const auto& element : request_json) {
     // Validate individual request objects in the batch
-    if (!element.is_object() || !Request::ValidateJson(element)) {
+    if (!element.is_object()) {
       // For invalid requests, create an immediate error response as a coroutine
       pending_requests.push_back(
           []() -> asio::awaitable<std::optional<nlohmann::json>> {

--- a/src/endpoint/dispatcher.cpp
+++ b/src/endpoint/dispatcher.cpp
@@ -26,40 +26,55 @@ void Dispatcher::RegisterNotification(
 
 auto Dispatcher::DispatchRequest(std::string request)
     -> asio::awaitable<std::optional<std::string>> {
-  nlohmann::json request_json;
+  nlohmann::json root;
   try {
-    request_json = nlohmann::json::parse(request);
+    root = nlohmann::json::parse(request);
   } catch (const nlohmann::json::parse_error& e) {
     co_return Response::CreateError(ErrorCode::kParseError).ToJson().dump();
   }
 
-  if (request_json.is_object()) {
-    auto request_obj = Request::FromJson(request_json);
-    if (!request_obj.has_value()) {
-      co_return Response::CreateError(request_obj.error()).ToJson().dump();
+  // Single request
+  if (root.is_object()) {
+    auto request = Request::FromJson(root);
+    if (!request.has_value()) {
+      co_return Response::CreateError(request.error()).ToJson().dump();
     }
+
+    auto response = co_await DispatchSingleRequest(request.value());
+    if (!response.has_value()) {
+      co_return std::nullopt;
+    }
+    co_return response.value().ToJson().dump();
   }
 
-  // Handle empty batch requests
-  if (request_json.is_array() && request_json.empty()) {
-    co_return Response::CreateError(ErrorCode::kInvalidRequest).ToJson().dump();
+  // Batch request
+  if (root.is_array()) {
+    if (root.empty()) {
+      co_return Response::CreateError(ErrorCode::kInvalidRequest)
+          .ToJson()
+          .dump();
+    }
+
+    std::vector<Request> requests;
+    std::vector<Response> responses;
+    for (const auto& element : root) {
+      auto request = Request::FromJson(element);
+      if (!request.has_value()) {
+        responses.push_back(Response::CreateError(request.error()));
+        continue;
+      }
+      requests.push_back(request.value());
+    }
+
+    auto dispatched = co_await DispatchBatchRequest(requests);
+    for (const auto& response : dispatched) {
+      responses.push_back(response);
+    }
+
+    co_return nlohmann::json(responses).dump();
   }
 
-  if (request_json.is_array()) {
-    co_return co_await DispatchBatchRequest(request_json);
-  }
-
-  auto request_obj = Request::FromJson(request_json);
-  if (!request_obj.has_value()) {
-    co_return Response::CreateError(request_obj.error()).ToJson().dump();
-  }
-
-  auto response_json = co_await DispatchSingleRequest(request_obj.value());
-  if (!response_json) {
-    co_return std::nullopt;
-  }
-
-  co_return response_json->ToJson().dump();
+  co_return Response::CreateError(ErrorCode::kInvalidRequest).ToJson().dump();
 }
 
 auto Dispatcher::DispatchSingleRequest(Request request)
@@ -93,47 +108,27 @@ auto Dispatcher::DispatchSingleRequest(Request request)
   co_return Response::CreateError(ErrorCode::kMethodNotFound, request.GetId());
 }
 
-auto Dispatcher::DispatchBatchRequest(nlohmann::json request_json)
-    -> asio::awaitable<std::optional<std::string>> {
-  if (request_json.empty()) {
-    co_return Response::CreateError(ErrorCode::kInvalidRequest).ToJson().dump();
-  }
-
-  std::vector<asio::awaitable<std::optional<Response>>> pending_requests;
-  pending_requests.reserve(request_json.size());
+auto Dispatcher::DispatchBatchRequest(std::vector<Request> requests)
+    -> asio::awaitable<std::vector<Response>> {
+  std::vector<asio::awaitable<std::optional<Response>>> pending;
+  pending.reserve(requests.size());
 
   // Queue all requests in parallel
-  for (const auto& element : request_json) {
-    // Validate individual request objects in the batch
-    if (!element.is_object()) {
-      // For invalid requests, create an immediate error response as a coroutine
-      pending_requests.push_back(
-          []() -> asio::awaitable<std::optional<Response>> {
-            auto error_json =
-                Response::CreateError(ErrorCode::kInvalidRequest, std::nullopt);
-            co_return error_json;
-          }());
-    } else {
-      // For valid requests, dispatch them normally
-      pending_requests.push_back(
-          DispatchSingleRequest(Request::FromJson(element).value()));
-    }
+  for (const auto& request : requests) {
+    // For valid requests, dispatch them normally
+    pending.push_back(DispatchSingleRequest(request));
   }
 
   // Wait for all requests to complete
-  std::vector<nlohmann::json> responses;
-  for (auto& pending_request : pending_requests) {
-    auto response = co_await std::move(pending_request);
-    if (response) {
-      responses.push_back(response->ToJson());
+  std::vector<Response> responses;
+  for (auto& awaitable_response : pending) {
+    auto response = co_await std::move(awaitable_response);
+    if (response.has_value()) {
+      responses.push_back(response.value());
     }
   }
 
-  if (responses.empty()) {
-    co_return std::nullopt;
-  }
-
-  co_return nlohmann::json(responses).dump();
+  co_return responses;
 }
 
 }  // namespace jsonrpc::endpoint

--- a/src/endpoint/dispatcher.cpp
+++ b/src/endpoint/dispatcher.cpp
@@ -49,34 +49,29 @@ auto Dispatcher::DispatchRequest(std::string request)
     co_return co_await DispatchBatchRequest(request_json);
   }
 
-  auto response_json = co_await DispatchSingleRequest(request_json);
+  auto request_obj = Request::FromJson(request_json);
+  if (!request_obj.has_value()) {
+    co_return Response::CreateError(request_obj.error()).ToJson().dump();
+  }
+
+  auto response_json = co_await DispatchSingleRequest(request_obj.value());
   if (!response_json) {
     co_return std::nullopt;
   }
 
-  co_return response_json->dump();
+  co_return response_json->ToJson().dump();
 }
 
-auto Dispatcher::DispatchSingleRequest(nlohmann::json request_json)
-    -> asio::awaitable<std::optional<nlohmann::json>> {
-  auto result = ValidateRequest(request_json);
-  if (!result) {
-    co_return Response::CreateError(result.error()).ToJson().dump();
-  }
+auto Dispatcher::DispatchSingleRequest(Request request)
+    -> asio::awaitable<std::optional<Response>> {
+  auto method = request.GetMethod();
 
-  auto request = Request::FromJson(request_json);
-  if (!request) {
-    co_return Response::CreateError(request.error()).ToJson().dump();
-  }
-
-  auto method = request->GetMethod();
-
-  if (request->IsNotification()) {
+  if (request.IsNotification()) {
     auto it = notification_handlers_.find(method);
     if (it != notification_handlers_.end()) {
       co_spawn(
           executor_,
-          [handler = it->second, params = request->GetParams()] {
+          [handler = it->second, params = request.GetParams()] {
             return handler(params);
           },
           asio::detached);
@@ -88,15 +83,14 @@ auto Dispatcher::DispatchSingleRequest(nlohmann::json request_json)
   if (it != method_handlers_.end()) {
     auto result = co_await asio::co_spawn(
         executor_,
-        [handler = it->second, params = request->GetParams()] {
+        [handler = it->second, params = request.GetParams()] {
           return handler(params);
         },
         asio::use_awaitable);
-    co_return Response::CreateSuccess(result, request->GetId()).ToJson();
+    co_return Response::CreateSuccess(result, request.GetId());
   }
 
-  co_return Response::CreateError(ErrorCode::kMethodNotFound, request->GetId())
-      .ToJson();
+  co_return Response::CreateError(ErrorCode::kMethodNotFound, request.GetId());
 }
 
 auto Dispatcher::DispatchBatchRequest(nlohmann::json request_json)
@@ -105,7 +99,7 @@ auto Dispatcher::DispatchBatchRequest(nlohmann::json request_json)
     co_return Response::CreateError(ErrorCode::kInvalidRequest).ToJson().dump();
   }
 
-  std::vector<asio::awaitable<std::optional<nlohmann::json>>> pending_requests;
+  std::vector<asio::awaitable<std::optional<Response>>> pending_requests;
   pending_requests.reserve(request_json.size());
 
   // Queue all requests in parallel
@@ -114,15 +108,15 @@ auto Dispatcher::DispatchBatchRequest(nlohmann::json request_json)
     if (!element.is_object()) {
       // For invalid requests, create an immediate error response as a coroutine
       pending_requests.push_back(
-          []() -> asio::awaitable<std::optional<nlohmann::json>> {
+          []() -> asio::awaitable<std::optional<Response>> {
             auto error_json =
-                Response::CreateError(ErrorCode::kInvalidRequest, std::nullopt)
-                    .ToJson();
+                Response::CreateError(ErrorCode::kInvalidRequest, std::nullopt);
             co_return error_json;
           }());
     } else {
       // For valid requests, dispatch them normally
-      pending_requests.push_back(DispatchSingleRequest(element));
+      pending_requests.push_back(
+          DispatchSingleRequest(Request::FromJson(element).value()));
     }
   }
 
@@ -131,7 +125,7 @@ auto Dispatcher::DispatchBatchRequest(nlohmann::json request_json)
   for (auto& pending_request : pending_requests) {
     auto response = co_await std::move(pending_request);
     if (response) {
-      responses.push_back(*response);
+      responses.push_back(response->ToJson());
     }
   }
 

--- a/src/endpoint/dispatcher.cpp
+++ b/src/endpoint/dispatcher.cpp
@@ -25,18 +25,22 @@ auto Dispatcher::DispatchRequest(std::string request)
   try {
     request_json = nlohmann::json::parse(request);
   } catch (const nlohmann::json::parse_error& e) {
-    co_return Response::CreateLibError(ErrorCode::kParseError).ToStr();
+    co_return Response::CreateLibError(ErrorCode::kParseError).ToJson().dump();
   }
 
   // Now validate the request
   if (request_json.is_object() && !Request::ValidateJson(request_json)) {
     // This is an invalid request error
-    co_return Response::CreateLibError(ErrorCode::kInvalidRequest).ToStr();
+    co_return Response::CreateLibError(ErrorCode::kInvalidRequest)
+        .ToJson()
+        .dump();
   }
 
   // Handle empty batch requests
   if (request_json.is_array() && request_json.empty()) {
-    co_return Response::CreateLibError(ErrorCode::kInvalidRequest).ToStr();
+    co_return Response::CreateLibError(ErrorCode::kInvalidRequest)
+        .ToJson()
+        .dump();
   }
 
   if (request_json.is_array()) {
@@ -93,7 +97,9 @@ auto Dispatcher::DispatchSingleRequest(nlohmann::json request_json)
 auto Dispatcher::DispatchBatchRequest(nlohmann::json request_json)
     -> asio::awaitable<std::optional<std::string>> {
   if (request_json.empty()) {
-    co_return Response::CreateLibError(ErrorCode::kInvalidRequest).ToStr();
+    co_return Response::CreateLibError(ErrorCode::kInvalidRequest)
+        .ToJson()
+        .dump();
   }
 
   std::vector<asio::awaitable<std::optional<nlohmann::json>>> pending_requests;
@@ -151,7 +157,7 @@ auto Dispatcher::ValidateRequest(const nlohmann::json& request_json)
     const auto& params = request_json["params"];
     if (!params.is_object() && !params.is_array() && !params.is_null()) {
       return Response::CreateLibError(
-          ErrorCode::kInvalidParams, "Params must be object or array");
+          ErrorCode::kInvalidRequest, "Params must be object or array");
     }
   }
 

--- a/src/endpoint/dispatcher.cpp
+++ b/src/endpoint/dispatcher.cpp
@@ -3,7 +3,12 @@
 #include <jsonrpc/endpoint/request.hpp>
 #include <spdlog/spdlog.h>
 
+#include "jsonrpc/endpoint/response.hpp"
+
 namespace jsonrpc::endpoint {
+
+using jsonrpc::error::ErrorCode;
+using jsonrpc::error::RpcError;
 
 Dispatcher::Dispatcher(asio::any_io_executor executor)
     : executor_(std::move(executor)) {
@@ -53,9 +58,9 @@ auto Dispatcher::DispatchRequest(std::string request)
 
 auto Dispatcher::DispatchSingleRequest(nlohmann::json request_json)
     -> asio::awaitable<std::optional<nlohmann::json>> {
-  auto validation_result = ValidateRequest(request_json);
-  if (validation_result) {
-    co_return validation_result->ToJson();
+  auto result = ValidateRequest(request_json);
+  if (!result) {
+    co_return Response::CreateError(result.error()).ToJson().dump();
   }
 
   Request request = Request::FromJson(request_json);
@@ -133,29 +138,29 @@ auto Dispatcher::DispatchBatchRequest(nlohmann::json request_json)
 }
 
 auto Dispatcher::ValidateRequest(const nlohmann::json& request_json)
-    -> std::optional<Response> {
+    -> std::expected<void, error::RpcError> {
   if (!request_json.contains("method")) {
-    return Response::CreateError(
-        ErrorCode::kInvalidRequest, "Method is required");
+    return std::unexpected(
+        error::RpcError{ErrorCode::kInvalidRequest, "Method is required"});
   }
 
   const auto& method = request_json["method"];
   if (!method.is_string()) {
-    return Response::CreateError(
-        ErrorCode::kInvalidRequest, "Method must be a string");
+    return std::unexpected(
+        error::RpcError{ErrorCode::kInvalidRequest, "Method must be a string"});
   }
 
   // For params, if present, must be object or array
   if (request_json.contains("params")) {
     const auto& params = request_json["params"];
     if (!params.is_object() && !params.is_array() && !params.is_null()) {
-      return Response::CreateError(
-          ErrorCode::kInvalidRequest, "Params must be object or array");
+      return std::unexpected(error::RpcError{
+          ErrorCode::kInvalidRequest, "Params must be object or array"});
     }
   }
 
   // Request is valid
-  return std::nullopt;
+  return {};
 }
 
 }  // namespace jsonrpc::endpoint

--- a/src/endpoint/dispatcher.cpp
+++ b/src/endpoint/dispatcher.cpp
@@ -41,10 +41,10 @@ auto Dispatcher::DispatchRequest(std::string request)
     }
 
     auto response = co_await DispatchSingleRequest(request.value());
-    if (!response.has_value()) {
-      co_return std::nullopt;
+    if (response.has_value()) {
+      co_return response.value().ToJson().dump();
     }
-    co_return response.value().ToJson().dump();
+    co_return std::nullopt;
   }
 
   // Batch request

--- a/src/endpoint/endpoint.cpp
+++ b/src/endpoint/endpoint.cpp
@@ -1,8 +1,6 @@
 #include "jsonrpc/endpoint/endpoint.hpp"
 
-#include <asio/co_spawn.hpp>
-#include <asio/detached.hpp>
-#include <asio/use_awaitable.hpp>
+#include <asio.hpp>
 #include <jsonrpc/error/error.hpp>
 #include <spdlog/spdlog.h>
 
@@ -45,7 +43,7 @@ auto RpcEndpoint::Start() -> asio::awaitable<std::expected<void, RpcError>> {
     co_return CreateClientError("RPC endpoint is already running");
   }
 
-  spdlog::info("Starting RPC endpoint");
+  spdlog::debug("Starting RPC endpoint");
   pending_requests_.clear();
 
   // Start the transport
@@ -86,17 +84,25 @@ auto RpcEndpoint::Shutdown() -> asio::awaitable<std::expected<void, RpcError>> {
     co_return std::expected<void, RpcError>{};
   }
 
-  spdlog::info("Shutting down RPC endpoint");
+  cancel_signal_.emit(asio::cancellation_type::all);
 
-  // Cancel all pending requests
-  asio::post(endpoint_strand_, [this]() {
-    for (auto &[id, request] : pending_requests_) {
-      request->Cancel(-32603, "RPC endpoint shutting down");
-    }
-    pending_requests_.clear();
-  });
+  spdlog::debug("Shutting down RPC endpoint");
 
-  // Close the transport - this ensures any pending operations are canceled
+  // Ensure all operations on the strand complete, including message processing
+  co_await asio::post(endpoint_strand_, asio::use_awaitable);
+
+  // Cancel pending requests
+  for (auto &[id, request] : pending_requests_) {
+    request->Cancel(-32603, "RPC endpoint shutting down");
+  }
+  pending_requests_.clear();
+
+  // Wait for the message loop to complete
+  if (message_loop_.valid()) {
+    co_await std::move(message_loop_);
+  }
+
+  // Now close the transport
   auto close_result = co_await transport_->Close();
   if (!close_result) {
     co_return std::unexpected(close_result.error());
@@ -169,41 +175,35 @@ auto RpcEndpoint::HasPendingRequests() const -> bool {
 }
 
 void RpcEndpoint::StartMessageProcessing() {
-  asio::co_spawn(
-      endpoint_strand_, [this] { return this->ProcessMessagesLoop(); },
-      asio::detached);
+  message_loop_ = asio::co_spawn(
+      endpoint_strand_,
+      [this] { return this->ProcessMessagesLoop(cancel_signal_.slot()); },
+      asio::use_awaitable);
 }
 
-auto RpcEndpoint::ProcessMessagesLoop() -> asio::awaitable<void> {
-  while (is_running_) {
-    try {
-      // Wait for the next message
-      auto message = co_await transport_->ReceiveMessage();
-      if (!message.has_value()) {
-        spdlog::error("Error receiving message: {}", message.error().message);
-        continue;
-      }
+namespace {
+auto RetryDelay(asio::any_io_executor exec) -> asio::awaitable<void> {
+  asio::steady_timer timer(exec, std::chrono::milliseconds(100));
+  co_await timer.async_wait(asio::use_awaitable);
+}
+}  // namespace
 
-      // Process the message
-      co_await HandleMessage(message.value());
-    } catch (const std::exception &e) {
-      spdlog::error("Error processing message: {}", e.what());
+auto RpcEndpoint::ProcessMessagesLoop(asio::cancellation_slot slot)
+    -> asio::awaitable<void> {
+  auto state = co_await asio::this_coro::cancellation_state;
+  while (is_running_ && !state.cancelled()) {
+    auto message_result = co_await transport_->ReceiveMessage();
+    if (!message_result) {
+      spdlog::error("Receive error: {}", message_result.error().message);
+      co_await RetryDelay(executor_);
+      continue;
+    }
 
-      if (!is_running_) {
-        break;  // Exit loop if we're shutting down
-      }
-
-      // We can't use co_await in a catch block, so we need to continue the loop
-      // and do the pause in the next iteration
-      asio::steady_timer retry_timer(executor_, std::chrono::milliseconds(100));
-
-      // Use a non-coroutine wait to prevent co_await in catch handler
-      asio::error_code ec;
-      retry_timer.wait(ec);
-
-      if (ec) {
-        spdlog::warn("Error waiting for retry timer: {}", ec.message());
-      }
+    auto handle_result = co_await HandleMessage(*message_result);
+    if (!handle_result) {
+      spdlog::error("Handle error: {}", handle_result.error().message);
+      co_await RetryDelay(executor_);
+      continue;
     }
   }
 }

--- a/src/endpoint/endpoint.cpp
+++ b/src/endpoint/endpoint.cpp
@@ -84,12 +84,12 @@ auto RpcEndpoint::Shutdown() -> asio::awaitable<std::expected<void, RpcError>> {
     co_return std::expected<void, RpcError>{};
   }
 
+  co_await asio::post(endpoint_strand_, asio::use_awaitable);
   cancel_signal_.emit(asio::cancellation_type::all);
 
   spdlog::debug("Shutting down RPC endpoint");
 
   // Ensure all operations on the strand complete, including message processing
-  co_await asio::post(endpoint_strand_, asio::use_awaitable);
 
   // Cancel pending requests
   for (auto &[id, request] : pending_requests_) {

--- a/src/endpoint/endpoint.cpp
+++ b/src/endpoint/endpoint.cpp
@@ -3,12 +3,18 @@
 #include <asio/co_spawn.hpp>
 #include <asio/detached.hpp>
 #include <asio/use_awaitable.hpp>
+#include <jsonrpc/error/error.hpp>
 #include <spdlog/spdlog.h>
 
 #include "jsonrpc/endpoint/request.hpp"
 #include "jsonrpc/endpoint/response.hpp"
 
 namespace jsonrpc::endpoint {
+
+using jsonrpc::error::CreateClientError;
+using jsonrpc::error::CreateServerError;
+using jsonrpc::error::ErrorCode;
+using jsonrpc::error::RpcError;
 
 RpcEndpoint::RpcEndpoint(
     asio::any_io_executor executor,
@@ -97,46 +103,31 @@ auto RpcEndpoint::Shutdown() -> asio::awaitable<void> {
 
 auto RpcEndpoint::SendMethodCall(
     std::string method, std::optional<nlohmann::json> params)
-    -> asio::awaitable<nlohmann::json> {
+    -> asio::awaitable<std::expected<nlohmann::json, RpcError>> {
   if (!is_running_) {
-    throw std::runtime_error("RPC endpoint is not running");
+    co_return CreateClientError("RPC endpoint is not running");
   }
 
-  // Get request ID from the executor context (thread-safe)
   auto request_id = GetNextRequestId();
-
-  // Create the request message
   Request request(method, std::move(params), request_id);
   std::string message = request.ToJson().dump();
 
-  // Create a pending request
   auto pending_request = std::make_shared<PendingRequest>(endpoint_strand_);
+  asio::post(endpoint_strand_, [this, request_id, pending_request] {
+    pending_requests_[request_id] = pending_request;
+  });
 
-  // Store the pending request under strand protection
-  asio::post(
-      endpoint_strand_, [this, id = request_id, req = pending_request]() {
-        pending_requests_[id] = req;
-      });
-
-  // Send the request
-  co_await transport_->SendMessage(message);
-
-  // Await the result
-  auto result = co_await pending_request->GetResult();
-
-  // Check if the result contains an error
-  if (result.contains("error")) {
-    // Extract error details
-    auto error = result["error"];
-    int code = error["code"].get<int>();
-    std::string msg = error["message"].get<std::string>();
-
-    // Report and throw
-    ReportError(static_cast<ErrorCode>(code), msg);
-    // throw RpcError(static_cast<ErrorCode>(code), msg);
+  auto send_result = co_await transport_->SendMessage(message);
+  if (!send_result) {
+    co_return std::unexpected(send_result.error());
   }
 
-  // Return the result
+  auto result = co_await pending_request->GetResult();
+  if (result.contains("error")) {
+    auto err = result["error"];
+    co_return CreateClientError(err["message"].get<std::string>());
+  }
+
   co_return result["result"];
 }
 
@@ -169,18 +160,6 @@ void RpcEndpoint::RegisterNotification(
 auto RpcEndpoint::HasPendingRequests() const -> bool {
   // This is safe to call without a strand because we're just checking if empty
   return !pending_requests_.empty();
-}
-
-void RpcEndpoint::SetErrorHandler(ErrorHandler handler) {
-  error_handler_ = std::move(handler);
-}
-
-void RpcEndpoint::ReportError(ErrorCode code, const std::string &message) {
-  if (error_handler_) {
-    error_handler_(code, message);
-  }
-
-  spdlog::error("JSON-RPC error ({}): {}", static_cast<int>(code), message);
 }
 
 void RpcEndpoint::StartMessageProcessing() {
@@ -233,7 +212,6 @@ auto RpcEndpoint::HandleMessage(std::string message) -> asio::awaitable<void> {
         (json_message.contains("result") || json_message.contains("error"))) {
       auto response = Response::FromJson(json_message);
       if (!response.has_value()) {
-        ReportError(response.error().code, response.error().message);
         co_return;
       }
       co_await HandleResponse(std::move(response.value()));
@@ -255,13 +233,14 @@ auto RpcEndpoint::HandleResponse(Response response) -> asio::awaitable<void> {
   // Get the request ID
   auto id_variant = response.GetId();
   if (!id_variant.has_value()) {
-    ReportError(ErrorCode::kInvalidRequest, "Response missing ID");
+    // ReportError(ErrorCode::kInvalidRequest, "Response missing ID");
     co_return;
   }
 
   // Extract the integer ID - we only support integer IDs in our implementation
   if (!std::holds_alternative<int64_t>(*id_variant)) {
-    ReportError(ErrorCode::kInvalidRequest, "Response ID must be an integer");
+    // ReportError(ErrorCode::kInvalidRequest, "Response ID must be an
+    // integer");
     co_return;
   }
 
@@ -285,9 +264,9 @@ auto RpcEndpoint::HandleResponse(Response response) -> asio::awaitable<void> {
   co_await asio::post(co_await asio::this_coro::executor, asio::use_awaitable);
 
   if (!found || !request) {
-    ReportError(
-        ErrorCode::kInvalidRequest,
-        "Received response for unknown request ID: " + std::to_string(id));
+    // ReportError(
+    //     ErrorCode::kInvalidRequest,
+    //     "Received response for unknown request ID: " + std::to_string(id));
     co_return;
   }
 

--- a/src/endpoint/endpoint.cpp
+++ b/src/endpoint/endpoint.cpp
@@ -133,7 +133,7 @@ auto RpcEndpoint::SendMethodCall(
 
     // Report and throw
     ReportError(static_cast<ErrorCode>(code), msg);
-    throw RpcError(static_cast<ErrorCode>(code), msg);
+    // throw RpcError(static_cast<ErrorCode>(code), msg);
   }
 
   // Return the result
@@ -231,8 +231,12 @@ auto RpcEndpoint::HandleMessage(std::string message) -> asio::awaitable<void> {
     // Check if it's a response
     if (json_message.contains("id") &&
         (json_message.contains("result") || json_message.contains("error"))) {
-      Response response(json_message);
-      co_await HandleResponse(std::move(response));
+      auto response = Response::FromJson(json_message);
+      if (!response.has_value()) {
+        ReportError(response.error().code, response.error().message);
+        co_return;
+      }
+      co_await HandleResponse(std::move(response.value()));
       co_return;
     }
 

--- a/src/endpoint/endpoint.cpp
+++ b/src/endpoint/endpoint.cpp
@@ -28,20 +28,15 @@ RpcEndpoint::RpcEndpoint(
 auto RpcEndpoint::CreateClient(
     asio::any_io_executor executor,
     std::unique_ptr<transport::Transport> transport)
-    -> asio::awaitable<std::unique_ptr<RpcEndpoint>> {
-  // Create the endpoint
+    -> asio::awaitable<std::expected<std::unique_ptr<RpcEndpoint>, RpcError>> {
   auto endpoint = std::make_unique<RpcEndpoint>(executor, std::move(transport));
 
-  // Start the endpoint and wait for it to be ready
-  try {
-    co_await endpoint->Start();
-    spdlog::debug("Client endpoint initialized");
-  } catch (const std::exception &e) {
-    spdlog::error("Error starting client endpoint: {}", e.what());
-    throw;
+  auto start_result = co_await endpoint->Start();
+  if (!start_result) {
+    co_return std::unexpected(start_result.error());
   }
 
-  // Return the fully initialized endpoint
+  spdlog::debug("Client endpoint initialized");
   co_return endpoint;
 }
 
@@ -66,10 +61,11 @@ auto RpcEndpoint::Start() -> asio::awaitable<std::expected<void, RpcError>> {
   co_return std::expected<void, RpcError>{};
 }
 
-auto RpcEndpoint::WaitForShutdown() -> asio::awaitable<void> {
+auto RpcEndpoint::WaitForShutdown()
+    -> asio::awaitable<std::expected<void, RpcError>> {
   // If already shut down, return immediately
   if (!is_running_) {
-    co_return;
+    co_return std::expected<void, RpcError>{};
   }
 
   // Create a timer to check if the service is running
@@ -81,11 +77,13 @@ auto RpcEndpoint::WaitForShutdown() -> asio::awaitable<void> {
     co_await timer.async_wait(asio::use_awaitable);
     timer.expires_after(std::chrono::milliseconds(100));
   }
+
+  co_return std::expected<void, RpcError>{};
 }
 
-auto RpcEndpoint::Shutdown() -> asio::awaitable<void> {
+auto RpcEndpoint::Shutdown() -> asio::awaitable<std::expected<void, RpcError>> {
   if (!is_running_.exchange(false)) {
-    co_return;
+    co_return std::expected<void, RpcError>{};
   }
 
   spdlog::info("Shutting down RPC endpoint");
@@ -99,9 +97,12 @@ auto RpcEndpoint::Shutdown() -> asio::awaitable<void> {
   });
 
   // Close the transport - this ensures any pending operations are canceled
-  co_await transport_->Close();
+  auto close_result = co_await transport_->Close();
+  if (!close_result) {
+    co_return std::unexpected(close_result.error());
+  }
 
-  co_return;
+  co_return std::expected<void, RpcError>{};
 }
 
 auto RpcEndpoint::SendMethodCall(
@@ -207,56 +208,51 @@ auto RpcEndpoint::ProcessMessagesLoop() -> asio::awaitable<void> {
   }
 }
 
-auto RpcEndpoint::HandleMessage(std::string message) -> asio::awaitable<void> {
-  try {
-    // Try to parse as a JSON object
-    auto json_message = nlohmann::json::parse(message);
+namespace {
+auto IsResponse(const nlohmann::json &msg) -> bool {
+  return msg.contains("id") &&
+         (msg.contains("result") || msg.contains("error"));
+}
+}  // namespace
 
-    // Check if it's a response
-    if (json_message.contains("id") &&
-        (json_message.contains("result") || json_message.contains("error"))) {
-      auto response = Response::FromJson(json_message);
-      if (!response.has_value()) {
-        co_return;
-      }
-      co_await HandleResponse(std::move(response.value()));
-      co_return;
-    }
-
-    // Try to handle as a request
-    auto response = co_await dispatcher_.DispatchRequest(message);
-    if (response) {
-      co_await transport_->SendMessage(*response);
-    }
-  } catch (const std::exception &e) {
-    spdlog::error("Error handling message: {}", e.what());
-    throw;
+auto RpcEndpoint::HandleMessage(std::string message)
+    -> asio::awaitable<std::expected<void, RpcError>> {
+  const auto json_message_result =
+      nlohmann::json::parse(message, nullptr, false);
+  if (json_message_result.is_discarded()) {
+    co_return std::unexpected(CreateClientError("Failed to parse message"));
   }
+  const auto &json_message = json_message_result;
+
+  if (IsResponse(json_message)) {
+    auto response = Response::FromJson(json_message);
+    if (!response.has_value()) {
+      co_return std::unexpected(CreateClientError("Invalid response"));
+    }
+    co_return co_await HandleResponse(std::move(response.value()));
+  }
+
+  if (auto response = co_await dispatcher_.DispatchRequest(message)) {
+    co_return co_await transport_->SendMessage(*response);
+  }
+
+  co_return std::expected<void, RpcError>{};
 }
 
-auto RpcEndpoint::HandleResponse(Response response) -> asio::awaitable<void> {
-  // Get the request ID
-  auto id_variant = response.GetId();
-  if (!id_variant.has_value()) {
-    // ReportError(ErrorCode::kInvalidRequest, "Response missing ID");
-    co_return;
+auto RpcEndpoint::HandleResponse(Response response)
+    -> asio::awaitable<std::expected<void, RpcError>> {
+  auto id_opt = response.GetId();
+  if (!id_opt || !std::holds_alternative<int64_t>(*id_opt)) {
+    co_return std::unexpected(
+        CreateClientError("Response ID missing or not int64"));
   }
 
-  // Extract the integer ID - we only support integer IDs in our implementation
-  if (!std::holds_alternative<int64_t>(*id_variant)) {
-    // ReportError(ErrorCode::kInvalidRequest, "Response ID must be an
-    // integer");
-    co_return;
-  }
+  const auto id = std::get<int64_t>(*id_opt);
 
-  auto id = std::get<int64_t>(*id_variant);
-
-  // Use a local variable to capture the pending request when found
   std::shared_ptr<PendingRequest> request;
   bool found = false;
 
-  // Find the request in a strand-protected way
-  asio::post(endpoint_strand_, [this, id, &request, &found]() {
+  asio::post(endpoint_strand_, [this, id, &request, &found] {
     auto it = pending_requests_.find(id);
     if (it != pending_requests_.end()) {
       request = it->second;
@@ -265,20 +261,15 @@ auto RpcEndpoint::HandleResponse(Response response) -> asio::awaitable<void> {
     }
   });
 
-  // Wait for the post to complete
   co_await asio::post(co_await asio::this_coro::executor, asio::use_awaitable);
 
   if (!found || !request) {
-    // ReportError(
-    //     ErrorCode::kInvalidRequest,
-    //     "Received response for unknown request ID: " + std::to_string(id));
-    co_return;
+    co_return std::unexpected(
+        CreateClientError("Unknown request ID: " + std::to_string(id)));
   }
 
-  // Set the result
   request->SetResult(response.ToJson());
-
-  co_return;
+  co_return std::expected<void, RpcError>{};
 }
 
 }  // namespace jsonrpc::endpoint

--- a/src/endpoint/endpoint.cpp
+++ b/src/endpoint/endpoint.cpp
@@ -193,10 +193,14 @@ auto RpcEndpoint::ProcessMessagesLoop() -> asio::awaitable<void> {
   while (is_running_) {
     try {
       // Wait for the next message
-      std::string message = co_await transport_->ReceiveMessage();
+      auto message = co_await transport_->ReceiveMessage();
+      if (!message.has_value()) {
+        spdlog::error("Error receiving message: {}", message.error().message);
+        continue;
+      }
 
       // Process the message
-      co_await HandleMessage(message);
+      co_await HandleMessage(message.value());
     } catch (const std::exception &e) {
       spdlog::error("Error processing message: {}", e.what());
 

--- a/src/endpoint/endpoint.cpp
+++ b/src/endpoint/endpoint.cpp
@@ -133,18 +133,20 @@ auto RpcEndpoint::SendMethodCall(
 
 auto RpcEndpoint::SendNotification(
     std::string method, std::optional<nlohmann::json> params)
-    -> asio::awaitable<void> {
+    -> asio::awaitable<std::expected<void, RpcError>> {
   if (!is_running_) {
-    throw std::runtime_error("RPC endpoint is not running");
+    co_return CreateClientError("RPC endpoint is not running");
   }
 
-  // Create the notification message (no ID)
   Request request(method, std::move(params));
   std::string message = request.ToJson().dump();
 
-  // Send the notification
-  co_await transport_->SendMessage(message);
-  co_return;
+  auto send_result = co_await transport_->SendMessage(message);
+  if (!send_result) {
+    co_return std::unexpected(send_result.error());
+  }
+
+  co_return std::expected<void, RpcError>{};
 }
 
 void RpcEndpoint::RegisterMethodCall(

--- a/src/endpoint/endpoint.cpp
+++ b/src/endpoint/endpoint.cpp
@@ -107,7 +107,7 @@ auto RpcEndpoint::SendMethodCall(
 
   // Create the request message
   Request request(method, std::move(params), request_id);
-  std::string message = request.Dump();
+  std::string message = request.ToJson().dump();
 
   // Create a pending request
   auto pending_request = std::make_shared<PendingRequest>(endpoint_strand_);
@@ -149,7 +149,7 @@ auto RpcEndpoint::SendNotification(
 
   // Create the notification message (no ID)
   Request request(method, std::move(params));
-  std::string message = request.Dump();
+  std::string message = request.ToJson().dump();
 
   // Send the notification
   co_await transport_->SendMessage(message);

--- a/src/endpoint/endpoint.cpp
+++ b/src/endpoint/endpoint.cpp
@@ -292,7 +292,7 @@ auto RpcEndpoint::HandleResponse(Response response) -> asio::awaitable<void> {
   }
 
   // Set the result
-  request->SetResult(response.GetJson());
+  request->SetResult(response.ToJson());
 
   co_return;
 }

--- a/src/endpoint/endpoint.cpp
+++ b/src/endpoint/endpoint.cpp
@@ -45,22 +45,25 @@ auto RpcEndpoint::CreateClient(
   co_return endpoint;
 }
 
-auto RpcEndpoint::Start() -> asio::awaitable<void> {
-  if (is_running_.exchange(true)) {  // Prevent double start
-    throw std::runtime_error("RPC endpoint is already running");
+auto RpcEndpoint::Start() -> asio::awaitable<std::expected<void, RpcError>> {
+  if (is_running_.exchange(true)) {
+    co_return CreateClientError("RPC endpoint is already running");
   }
 
   spdlog::info("Starting RPC endpoint");
   pending_requests_.clear();
 
   // Start the transport
-  co_await transport_->Start();
+  auto start_result = co_await transport_->Start();
+  if (!start_result) {
+    co_return std::unexpected(start_result.error());
+  }
 
   // Start message processing on the endpoint strand
   StartMessageProcessing();
 
   // Ensure Start completes before Wait checks is_running_
-  co_return;
+  co_return std::expected<void, RpcError>{};
 }
 
 auto RpcEndpoint::WaitForShutdown() -> asio::awaitable<void> {

--- a/src/endpoint/request.cpp
+++ b/src/endpoint/request.cpp
@@ -54,7 +54,7 @@ auto Request::ValidateJson(const nlohmann::json& json_obj) -> bool {
   if (!json_obj.is_object()) {
     return false;
   }
-  if (!json_obj.contains("jsonrpc") || json_obj["jsonrpc"] != "2.0") {
+  if (!json_obj.contains("jsonrpc") || json_obj["jsonrpc"] != kJsonRpcVersion) {
     return false;
   }
   if (!json_obj.contains("method") || !json_obj["method"].is_string()) {
@@ -92,7 +92,7 @@ auto Request::Dump() const -> std::string {
 
 auto Request::ToJson() const -> nlohmann::json {
   nlohmann::json json_obj;
-  json_obj["jsonrpc"] = "2.0";
+  json_obj["jsonrpc"] = kJsonRpcVersion;
   json_obj["method"] = method_;
 
   if (params_.has_value()) {

--- a/src/endpoint/request.cpp
+++ b/src/endpoint/request.cpp
@@ -47,7 +47,7 @@ auto Request::FromJson(const nlohmann::json& json_obj) -> Request {
     id = id_json.get<int64_t>();
   }
 
-  return Request(std::move(method), std::move(params), std::move(id));
+  return {std::move(method), std::move(params), std::move(id)};
 }
 
 auto Request::ValidateJson(const nlohmann::json& json_obj) -> bool {

--- a/src/endpoint/request.cpp
+++ b/src/endpoint/request.cpp
@@ -2,6 +2,9 @@
 
 namespace jsonrpc::endpoint {
 
+using error::ErrorCode;
+using error::RpcError;
+
 Request::Request(
     std::string method, std::optional<nlohmann::json> params,
     const std::function<RequestId()>& id_generator)
@@ -25,9 +28,24 @@ Request::Request(std::string method, std::optional<nlohmann::json> params)
       is_notification_(true) {  // No ID for notifications
 }
 
-auto Request::FromJson(const nlohmann::json& json_obj) -> Request {
-  if (!ValidateJson(json_obj)) {
-    throw std::invalid_argument("Invalid JSON-RPC request");
+auto Request::FromJson(const nlohmann::json& json_obj)
+    -> std::expected<Request, error::RpcError> {
+  using error::ErrorCode;
+  using error::RpcError;
+
+  if (!json_obj.is_object()) {
+    return std::unexpected(
+        RpcError{ErrorCode::kInvalidRequest, "Request must be a JSON object"});
+  }
+
+  if (!json_obj.contains("jsonrpc") || json_obj["jsonrpc"] != kJsonRpcVersion) {
+    return std::unexpected(RpcError{
+        ErrorCode::kInvalidRequest, "Missing or invalid 'jsonrpc' version"});
+  }
+
+  if (!json_obj.contains("method") || !json_obj["method"].is_string()) {
+    return std::unexpected(
+        RpcError{ErrorCode::kInvalidRequest, "Missing or invalid 'method'"});
   }
 
   auto method = json_obj["method"].get<std::string>();
@@ -35,11 +53,25 @@ auto Request::FromJson(const nlohmann::json& json_obj) -> Request {
                     ? std::optional<nlohmann::json>(json_obj["params"])
                     : std::nullopt;
 
+  if (json_obj.contains("params")) {
+    const auto& p = json_obj["params"];
+    if (!p.is_array() && !p.is_object() && !p.is_null()) {
+      return std::unexpected(RpcError{
+          ErrorCode::kInvalidRequest,
+          "'params' must be object, array, or null"});
+    }
+  }
+
   if (!json_obj.contains("id")) {
     return Request(std::move(method), std::move(params));  // Notification
   }
 
   const auto& id_json = json_obj["id"];
+  if (!id_json.is_string() && !id_json.is_number_integer()) {
+    return std::unexpected(
+        RpcError{ErrorCode::kInvalidRequest, "Invalid 'id' type"});
+  }
+
   RequestId id;
   if (id_json.is_string()) {
     id = id_json.get<std::string>();
@@ -47,35 +79,7 @@ auto Request::FromJson(const nlohmann::json& json_obj) -> Request {
     id = id_json.get<int64_t>();
   }
 
-  return {std::move(method), std::move(params), std::move(id)};
-}
-
-auto Request::ValidateJson(const nlohmann::json& json_obj) -> bool {
-  if (!json_obj.is_object()) {
-    return false;
-  }
-  if (!json_obj.contains("jsonrpc") || json_obj["jsonrpc"] != kJsonRpcVersion) {
-    return false;
-  }
-  if (!json_obj.contains("method") || !json_obj["method"].is_string()) {
-    return false;
-  }
-
-  if (json_obj.contains("params")) {
-    const auto& params = json_obj["params"];
-    if (!params.is_array() && !params.is_object() && !params.is_null()) {
-      return false;
-    }
-  }
-
-  if (json_obj.contains("id")) {
-    const auto& id = json_obj["id"];
-    if (!id.is_string() && !id.is_number_integer()) {
-      return false;
-    }
-  }
-
-  return true;
+  return Request(std::move(method), std::move(params), std::move(id));
 }
 
 auto Request::RequiresResponse() const -> bool {
@@ -84,10 +88,6 @@ auto Request::RequiresResponse() const -> bool {
 
 auto Request::GetId() const -> RequestId {
   return id_;
-}
-
-auto Request::Dump() const -> std::string {
-  return ToJson().dump();
 }
 
 auto Request::ToJson() const -> nlohmann::json {

--- a/src/endpoint/response.cpp
+++ b/src/endpoint/response.cpp
@@ -1,20 +1,16 @@
 #include "jsonrpc/endpoint/response.hpp"
 
+#include <jsonrpc/error/error.hpp>
+
 namespace jsonrpc::endpoint {
 
-Response::Response(Response&& other) noexcept
-    : response_(std::move(other.response_)) {
-}
-
-Response::Response(nlohmann::json response) : response_(std::move(response)) {
-  ValidateResponse();
-}
-
-auto Response::FromJson(const nlohmann::json& json) -> Response {
-  if (!json.contains("jsonrpc") || json["jsonrpc"] != "2.0") {
-    throw std::invalid_argument("Invalid JSON-RPC version");
+auto Response::FromJson(const nlohmann::json& json)
+    -> std::expected<Response, error::RpcError> {
+  Response r{json};
+  if (auto result = r.ValidateResponse(); !result) {
+    return std::unexpected(result.error());
   }
-  return Response(json);
+  return r;
 }
 
 auto Response::CreateResult(
@@ -121,28 +117,33 @@ auto Response::CreateErrorResponse(
   return response;
 }
 
-void Response::ValidateResponse() const {
+auto Response::ValidateResponse() const
+    -> std::expected<void, error::RpcError> {
+  using error::CreateInvalidRequest;
+
   if (!response_.contains("jsonrpc") || response_["jsonrpc"] != "2.0") {
-    throw std::invalid_argument("Invalid JSON-RPC version");
+    return std::unexpected(CreateInvalidRequest("Invalid JSON-RPC version"));
   }
 
   if (!response_.contains("result") && !response_.contains("error")) {
-    throw std::invalid_argument(
-        "Response must contain either 'result' or 'error' field");
+    return std::unexpected(CreateInvalidRequest(
+        "Response must contain either 'result' or 'error' field"));
   }
 
   if (response_.contains("result") && response_.contains("error")) {
-    throw std::invalid_argument(
-        "Response cannot contain both 'result' and 'error' fields");
+    return std::unexpected(CreateInvalidRequest(
+        "Response cannot contain both 'result' and 'error' fields"));
   }
 
   if (response_.contains("error")) {
     const auto& error = response_["error"];
     if (!error.contains("code") || !error.contains("message")) {
-      throw std::invalid_argument(
-          "Error object must contain 'code' and 'message' fields");
+      return std::unexpected(CreateInvalidRequest(
+          "Error object must contain 'code' and 'message' fields"));
     }
   }
+
+  return {};
 }
 
 }  // namespace jsonrpc::endpoint

--- a/src/endpoint/response.cpp
+++ b/src/endpoint/response.cpp
@@ -41,6 +41,13 @@ auto Response::CreateError(ErrorCode code, const std::optional<RequestId>& id)
 }
 
 auto Response::CreateError(
+    const RpcError& error, const std::optional<RequestId>& id) -> Response {
+  nlohmann::json error_json = {
+      {"code", static_cast<int>(error.code)}, {"message", error.message}};
+  return CreateError(error_json, id);
+}
+
+auto Response::CreateError(
     const nlohmann::json& error, const std::optional<RequestId>& id)
     -> Response {
   nlohmann::json response = {{"jsonrpc", kJsonRpcVersion}, {"error", error}};

--- a/src/endpoint/response.cpp
+++ b/src/endpoint/response.cpp
@@ -4,6 +4,8 @@
 
 namespace jsonrpc::endpoint {
 
+using jsonrpc::error::RpcError;
+
 auto Response::FromJson(const nlohmann::json& json)
     -> std::expected<Response, error::RpcError> {
   Response r{json};
@@ -24,36 +26,18 @@ auto Response::CreateResult(
 }
 
 auto Response::CreateLibError(
-    ErrorCode error_code, const std::optional<RequestId>& id) -> Response {
-  const int code = static_cast<int>(error_code);
-  std::string message;
-  switch (error_code) {
-    case ErrorCode::kParseError:
-      message = "Parse error";
-      break;
-    case ErrorCode::kInvalidRequest:
-      message = "Invalid Request";
-      break;
-    case ErrorCode::kMethodNotFound:
-      message = "Method not found";
-      break;
-    case ErrorCode::kInvalidParams:
-      message = "Invalid params";
-      break;
-    case ErrorCode::kInternalError:
-      message = "Internal error";
-      break;
-    case ErrorCode::kServerError:
-      message = "Server error";
-      break;
-    case ErrorCode::kTransportError:
-      message = "Transport error";
-      break;
-    case ErrorCode::kTimeoutError:
-      message = "Timeout error";
-      break;
+    ErrorCode code, const std::optional<RequestId>& id) -> Response {
+  RpcError err{code};
+
+  nlohmann::json error = {
+      {"code", static_cast<int>(err.code)}, {"message", err.message}};
+  nlohmann::json response = {{"jsonrpc", "2.0"}, {"error", error}};
+  if (id) {
+    std::visit([&response](const auto& v) { response["id"] = v; }, *id);
+  } else {
+    response["id"] = nullptr;
   }
-  return Response{CreateErrorResponse(message, code, id)};
+  return Response{std::move(response)};
 }
 
 auto Response::CreateUserError(
@@ -100,46 +84,31 @@ auto Response::ToJson() const -> nlohmann::json {
   return response_;
 }
 
-auto Response::ToStr() const -> std::string {
-  return response_.dump();
-}
-
-auto Response::CreateErrorResponse(
-    const std::string& message, int code, const std::optional<RequestId>& id)
-    -> nlohmann::json {
-  nlohmann::json error = {{"code", code}, {"message", message}};
-  nlohmann::json response = {{"jsonrpc", "2.0"}, {"error", error}};
-  if (id) {
-    std::visit([&response](const auto& v) { response["id"] = v; }, *id);
-  } else {
-    response["id"] = nullptr;
-  }
-  return response;
+inline auto InvalidRequestError(std::string message) {
+  return std::unexpected(RpcError{ErrorCode::kInvalidRequest, message});
 }
 
 auto Response::ValidateResponse() const
     -> std::expected<void, error::RpcError> {
-  using error::CreateInvalidRequest;
-
   if (!response_.contains("jsonrpc") || response_["jsonrpc"] != "2.0") {
-    return std::unexpected(CreateInvalidRequest("Invalid JSON-RPC version"));
+    return InvalidRequestError("Invalid JSON-RPC version");
   }
 
   if (!response_.contains("result") && !response_.contains("error")) {
-    return std::unexpected(CreateInvalidRequest(
-        "Response must contain either 'result' or 'error' field"));
+    return InvalidRequestError(
+        "Response must contain either 'result' or 'error' field");
   }
 
   if (response_.contains("result") && response_.contains("error")) {
-    return std::unexpected(CreateInvalidRequest(
-        "Response cannot contain both 'result' and 'error' fields"));
+    return InvalidRequestError(
+        "Response cannot contain both 'result' and 'error' fields");
   }
 
   if (response_.contains("error")) {
     const auto& error = response_["error"];
     if (!error.contains("code") || !error.contains("message")) {
-      return std::unexpected(CreateInvalidRequest(
-          "Error object must contain 'code' and 'message' fields"));
+      return InvalidRequestError(
+          "Error object must contain 'code' and 'message' fields");
     }
   }
 

--- a/src/endpoint/response.cpp
+++ b/src/endpoint/response.cpp
@@ -15,7 +15,7 @@ auto Response::FromJson(const nlohmann::json& json)
   return r;
 }
 
-auto Response::CreateResult(
+auto Response::CreateSuccess(
     const nlohmann::json& result, const std::optional<RequestId>& id)
     -> Response {
   nlohmann::json response = {{"jsonrpc", "2.0"}, {"result", result}};
@@ -25,8 +25,8 @@ auto Response::CreateResult(
   return Response{std::move(response)};
 }
 
-auto Response::CreateLibError(
-    ErrorCode code, const std::optional<RequestId>& id) -> Response {
+auto Response::CreateError(ErrorCode code, const std::optional<RequestId>& id)
+    -> Response {
   RpcError err{code};
 
   nlohmann::json error = {
@@ -40,7 +40,7 @@ auto Response::CreateLibError(
   return Response{std::move(response)};
 }
 
-auto Response::CreateUserError(
+auto Response::CreateError(
     const nlohmann::json& error, const std::optional<RequestId>& id)
     -> Response {
   nlohmann::json response = {{"jsonrpc", "2.0"}, {"error", error}};
@@ -84,30 +84,32 @@ auto Response::ToJson() const -> nlohmann::json {
   return response_;
 }
 
-inline auto InvalidRequestError(std::string message) {
+namespace {
+inline auto CreateInvalidRequest(std::string message) {
   return std::unexpected(RpcError{ErrorCode::kInvalidRequest, message});
 }
+}  // namespace
 
 auto Response::ValidateResponse() const
     -> std::expected<void, error::RpcError> {
   if (!response_.contains("jsonrpc") || response_["jsonrpc"] != "2.0") {
-    return InvalidRequestError("Invalid JSON-RPC version");
+    return CreateInvalidRequest("Invalid JSON-RPC version");
   }
 
   if (!response_.contains("result") && !response_.contains("error")) {
-    return InvalidRequestError(
+    return CreateInvalidRequest(
         "Response must contain either 'result' or 'error' field");
   }
 
   if (response_.contains("result") && response_.contains("error")) {
-    return InvalidRequestError(
+    return CreateInvalidRequest(
         "Response cannot contain both 'result' and 'error' fields");
   }
 
   if (response_.contains("error")) {
     const auto& error = response_["error"];
     if (!error.contains("code") || !error.contains("message")) {
-      return InvalidRequestError(
+      return CreateInvalidRequest(
           "Error object must contain 'code' and 'message' fields");
     }
   }

--- a/src/endpoint/response.cpp
+++ b/src/endpoint/response.cpp
@@ -18,7 +18,7 @@ auto Response::FromJson(const nlohmann::json& json)
 auto Response::CreateSuccess(
     const nlohmann::json& result, const std::optional<RequestId>& id)
     -> Response {
-  nlohmann::json response = {{"jsonrpc", "2.0"}, {"result", result}};
+  nlohmann::json response = {{"jsonrpc", kJsonRpcVersion}, {"result", result}};
   if (id) {
     std::visit([&response](const auto& v) { response["id"] = v; }, *id);
   }
@@ -31,7 +31,7 @@ auto Response::CreateError(ErrorCode code, const std::optional<RequestId>& id)
 
   nlohmann::json error = {
       {"code", static_cast<int>(err.code)}, {"message", err.message}};
-  nlohmann::json response = {{"jsonrpc", "2.0"}, {"error", error}};
+  nlohmann::json response = {{"jsonrpc", kJsonRpcVersion}, {"error", error}};
   if (id) {
     std::visit([&response](const auto& v) { response["id"] = v; }, *id);
   } else {
@@ -43,7 +43,7 @@ auto Response::CreateError(ErrorCode code, const std::optional<RequestId>& id)
 auto Response::CreateError(
     const nlohmann::json& error, const std::optional<RequestId>& id)
     -> Response {
-  nlohmann::json response = {{"jsonrpc", "2.0"}, {"error", error}};
+  nlohmann::json response = {{"jsonrpc", kJsonRpcVersion}, {"error", error}};
   if (id) {
     std::visit([&response](const auto& v) { response["id"] = v; }, *id);
   }
@@ -92,7 +92,8 @@ inline auto CreateInvalidRequest(std::string message) {
 
 auto Response::ValidateResponse() const
     -> std::expected<void, error::RpcError> {
-  if (!response_.contains("jsonrpc") || response_["jsonrpc"] != "2.0") {
+  if (!response_.contains("jsonrpc") ||
+      response_["jsonrpc"] != kJsonRpcVersion) {
     return CreateInvalidRequest("Invalid JSON-RPC version");
   }
 

--- a/src/transport/framed_pipe_transport.cpp
+++ b/src/transport/framed_pipe_transport.cpp
@@ -1,9 +1,5 @@
 #include "jsonrpc/transport/framed_pipe_transport.hpp"
 
-#include <array>
-#include <string_view>
-#include <unistd.h>
-
 #include <spdlog/spdlog.h>
 
 namespace jsonrpc::transport {
@@ -20,11 +16,11 @@ auto FramedPipeTransport::SendMessage(std::string message)
   co_return co_await PipeTransport::SendMessage(std::move(framed_message));
 }
 
-auto FramedPipeTransport::ReceiveMessage() -> asio::awaitable<std::string> {
+auto FramedPipeTransport::ReceiveMessage()
+    -> asio::awaitable<std::expected<std::string, error::RpcError>> {
   while (true) {
     // Try to deframe from existing buffer
     auto result = framer_.TryDeframe(read_buffer_);
-
     if (result.complete) {
       read_buffer_.erase(0, result.consumed_bytes);
       co_return result.message;
@@ -32,19 +28,17 @@ auto FramedPipeTransport::ReceiveMessage() -> asio::awaitable<std::string> {
 
     if (!result.error.empty()) {
       spdlog::error("Framing error: {}", result.error);
-      throw std::runtime_error(result.error);
+      co_return std::unexpected(
+          error::CreateTransportError("Framing error: " + result.error));
     }
 
-    // Need more data
-    std::array<char, 4096> buffer{};
-    size_t n = co_await GetSocket().async_read_some(
-        asio::buffer(buffer.data(), buffer.size()), asio::use_awaitable);
-
-    if (n == 0) {
-      throw std::runtime_error("Connection closed by peer");
+    // Get more data using base class receive
+    auto chunk_result = co_await PipeTransport::ReceiveMessage();
+    if (!chunk_result) {
+      co_return std::unexpected(chunk_result.error());
     }
 
-    read_buffer_.append(std::string_view(buffer.data(), n));
+    read_buffer_ += *chunk_result;  // append new data
   }
 }
 

--- a/src/transport/framed_pipe_transport.cpp
+++ b/src/transport/framed_pipe_transport.cpp
@@ -15,10 +15,9 @@ FramedPipeTransport::FramedPipeTransport(
 }
 
 auto FramedPipeTransport::SendMessage(std::string message)
-    -> asio::awaitable<void> {
+    -> asio::awaitable<std::expected<void, error::RpcError>> {
   auto framed_message = MessageFramer::Frame(message);
-  co_await asio::async_write(
-      GetSocket(), asio::buffer(framed_message), asio::use_awaitable);
+  co_return co_await PipeTransport::SendMessage(std::move(framed_message));
 }
 
 auto FramedPipeTransport::ReceiveMessage() -> asio::awaitable<std::string> {

--- a/src/transport/framed_pipe_transport.cpp
+++ b/src/transport/framed_pipe_transport.cpp
@@ -28,8 +28,7 @@ auto FramedPipeTransport::ReceiveMessage()
 
     if (!result.error.empty()) {
       spdlog::error("Framing error: {}", result.error);
-      co_return std::unexpected(
-          error::CreateTransportError("Framing error: " + result.error));
+      co_return error::CreateTransportError("Framing error: " + result.error);
     }
 
     // Get more data using base class receive

--- a/src/transport/pipe_transport.cpp
+++ b/src/transport/pipe_transport.cpp
@@ -20,13 +20,13 @@ PipeTransport::PipeTransport(
 }
 
 PipeTransport::~PipeTransport() {
-  try {
-    // If we haven't closed explicitly, do it now synchronously
-    if (!is_closed_) {
+  if (!is_closed_) {
+    spdlog::debug("PipeTransport destructor triggering CloseNow()");
+    try {
       CloseNow();
+    } catch (const std::exception &e) {
+      spdlog::error("Error in PipeTransport destructor: {}", e.what());
     }
-  } catch (const std::exception &e) {
-    spdlog::error("Error in PipeTransport destructor: {}", e.what());
   }
 }
 

--- a/src/transport/pipe_transport.cpp
+++ b/src/transport/pipe_transport.cpp
@@ -40,49 +40,6 @@ PipeTransport::~PipeTransport() {
   }
 }
 
-void PipeTransport::CloseNow() {
-  // Set the closed flag to prevent concurrent operations
-  is_closed_ = true;
-  is_connected_ = false;
-
-  try {
-    // Cancel and close the socket synchronously
-    if (socket_.is_open()) {
-      spdlog::debug("Closing socket synchronously");
-      socket_.cancel();
-      asio::error_code ec;
-      socket_.close(ec);
-      if (ec) {
-        spdlog::warn("Error closing socket: {}", ec.message());
-      }
-    }
-
-    // Cancel and close the acceptor safely
-    if (is_server_ && acceptor_ && acceptor_->is_open()) {
-      spdlog::debug("Closing acceptor synchronously");
-      acceptor_->cancel();
-      asio::error_code ec;
-      acceptor_->close(ec);
-      if (ec) {
-        spdlog::warn("Error closing acceptor: {}", ec.message());
-      }
-    }
-
-    // Clean up the socket file
-    if (is_server_ && !socket_path_.empty() &&
-        std::filesystem::exists(socket_path_)) {
-      try {
-        std::filesystem::remove(socket_path_);
-        spdlog::debug("Removed socket file: {}", socket_path_);
-      } catch (const std::exception &e) {
-        spdlog::warn("Error removing socket file: {}", e.what());
-      }
-    }
-  } catch (const std::exception &e) {
-    spdlog::error("Error in synchronous close: {}", e.what());
-  }
-}
-
 auto PipeTransport::Start()
     -> asio::awaitable<std::expected<void, error::RpcError>> {
   co_await asio::post(GetStrand(), asio::use_awaitable);
@@ -124,6 +81,98 @@ auto PipeTransport::Start()
   is_started_ = true;
   spdlog::debug("PipeTransport successfully started");
   co_return std::expected<void, error::RpcError>();
+}
+
+auto PipeTransport::Close()
+    -> asio::awaitable<std::expected<void, error::RpcError>> {
+  co_await asio::post(GetStrand(), asio::use_awaitable);
+
+  if (is_closed_) {
+    spdlog::debug("PipeTransport already closed");
+    co_return std::expected<void, error::RpcError>();
+  }
+
+  is_closed_ = true;
+  is_connected_ = false;
+
+  // Cancel and close the socket safely
+  std::error_code ec;
+  if (socket_.is_open()) {
+    socket_.cancel(ec);
+    if (ec) {
+      spdlog::warn("Error canceling socket: {}", ec.message());
+    }
+    socket_.close(ec);
+    if (ec) {
+      spdlog::warn("Error closing socket: {}", ec.message());
+    }
+  }
+
+  // clean up acceptor if this is a server
+  if (is_server_ && acceptor_) {
+    acceptor_->cancel(ec);
+    if (ec) {
+      spdlog::warn("Error canceling acceptor: {}", ec.message());
+    }
+    acceptor_->close(ec);
+    if (ec) {
+      spdlog::warn("Error closing acceptor: {}", ec.message());
+    }
+  }
+
+  // Clean up the socket file if this is a server
+  if (is_server_ && !socket_path_.empty()) {
+    auto result = RemoveExistingSocketFile();
+    if (!result) {
+      spdlog::warn("Error removing socket file: {}", result.error().message);
+    }
+  }
+
+  spdlog::debug("PipeTransport closed");
+  co_return std::expected<void, error::RpcError>();
+}
+
+void PipeTransport::CloseNow() {
+  // Set the closed flag to prevent concurrent operations
+  is_closed_ = true;
+  is_connected_ = false;
+
+  try {
+    // Cancel and close the socket synchronously
+    if (socket_.is_open()) {
+      spdlog::debug("Closing socket synchronously");
+      socket_.cancel();
+      asio::error_code ec;
+      socket_.close(ec);
+      if (ec) {
+        spdlog::warn("Error closing socket: {}", ec.message());
+      }
+    }
+
+    // Cancel and close the acceptor safely
+    if (is_server_ && acceptor_ && acceptor_->is_open()) {
+      spdlog::debug("Closing acceptor synchronously");
+      acceptor_->cancel();
+      asio::error_code ec;
+      acceptor_->close(ec);
+      if (ec) {
+        spdlog::warn("Error closing acceptor: {}", ec.message());
+      }
+    }
+
+    // Clean up the socket file
+    if (is_server_ && !socket_path_.empty() &&
+        std::filesystem::exists(socket_path_)) {
+      try {
+        std::filesystem::remove(socket_path_);
+        spdlog::debug("Removed socket file: {}", socket_path_);
+      } catch (const std::exception &e) {
+        spdlog::warn("Error removing socket file: {}", e.what());
+      }
+    }
+  } catch (const std::exception &e) {
+    spdlog::error("Error in synchronous close: {}", e.what());
+  }
 }
 
 auto PipeTransport::GetSocket() -> asio::local::stream_protocol::socket & {
@@ -226,63 +275,6 @@ auto PipeTransport::ReceiveMessage() -> asio::awaitable<std::string> {
     throw;
   } catch (const std::exception &e) {
     spdlog::error("Error receiving message: {}", e.what());
-    throw;
-  }
-}
-
-auto PipeTransport::Close() -> asio::awaitable<void> {
-  try {
-    co_await asio::post(GetStrand(), asio::use_awaitable);
-
-    spdlog::debug("Closing pipe transport");
-
-    if (is_closed_) {
-      co_return;  // Already closed
-    }
-
-    is_closed_ = true;
-    is_connected_ = false;
-
-    // Cancel and close the socket safely
-    if (socket_.is_open()) {
-      spdlog::debug("Closing socket");
-      socket_.cancel();
-      asio::error_code ec;
-      socket_.close(ec);
-      if (ec) {
-        spdlog::warn("Error closing socket: {}", ec.message());
-      }
-    }
-
-    // Cancel and close the acceptor safely
-    if (is_server_ && acceptor_ && acceptor_->is_open()) {
-      spdlog::debug("Closing acceptor");
-      acceptor_->cancel();
-      asio::error_code ec;
-      acceptor_->close(ec);
-      if (ec) {
-        spdlog::warn("Error closing acceptor: {}", ec.message());
-      }
-    }
-
-    // Ensure the socket file is removed only after closing the socket
-    if (is_server_ && !socket_path_.empty() &&
-        std::filesystem::exists(socket_path_)) {
-      try {
-        std::filesystem::remove(socket_path_);
-        spdlog::debug("Removed socket file: {}", socket_path_);
-      } catch (const std::exception &e) {
-        spdlog::warn("Error removing socket file: {}", e.what());
-      }
-    }
-
-    // Add an additional synchronization point to ensure all operations posted
-    // to the strand complete
-    co_await asio::post(GetStrand(), asio::use_awaitable);
-
-    co_return;
-  } catch (const std::exception &e) {
-    spdlog::error("Error closing pipe transport: {}", e.what());
     throw;
   }
 }

--- a/src/transport/pipe_transport.cpp
+++ b/src/transport/pipe_transport.cpp
@@ -48,7 +48,7 @@ auto PipeTransport::Start()
 
   if (is_server_) {
     // For server, bind and listen for connections
-    spdlog::info("Starting PipeTransport server at {}", socket_path_);
+    spdlog::debug("Starting PipeTransport server at {}", socket_path_);
     auto result = co_await BindAndListen();
     if (!result) {
       spdlog::error(
@@ -57,7 +57,7 @@ auto PipeTransport::Start()
     }
   } else {
     // For client, connect to the server
-    spdlog::info("Connecting PipeTransport client to {}", socket_path_);
+    spdlog::debug("Connecting PipeTransport client to {}", socket_path_);
     auto result = co_await Connect();
     if (!result) {
       spdlog::error(

--- a/src/transport/pipe_transport.cpp
+++ b/src/transport/pipe_transport.cpp
@@ -83,18 +83,21 @@ void PipeTransport::CloseNow() {
   }
 }
 
-auto PipeTransport::Start() -> asio::awaitable<void> {
+auto PipeTransport::Start()
+    -> asio::awaitable<std::expected<void, error::RpcError>> {
   try {
     co_await asio::post(GetStrand(), asio::use_awaitable);
 
     if (is_started_) {
       spdlog::debug("PipeTransport already started");
-      co_return;
+      co_return std::unexpected(
+          error::CreateTransportError("PipeTransport already started"));
     }
 
     if (is_closed_) {
       spdlog::error("Cannot start a closed transport");
-      throw std::runtime_error("Cannot start a closed transport");
+      co_return std::unexpected(
+          error::CreateTransportError("Cannot start a closed transport"));
     }
 
     // Set started flag before performing operations
@@ -111,7 +114,7 @@ auto PipeTransport::Start() -> asio::awaitable<void> {
       spdlog::debug("PipeTransport client connected to {}", socket_path_);
     }
 
-    co_return;
+    co_return std::expected<void, error::RpcError>();
   } catch (const std::exception &e) {
     spdlog::error("Error in PipeTransport::Start(): {}", e.what());
     is_started_ = false;
@@ -123,17 +126,24 @@ auto PipeTransport::GetSocket() -> asio::local::stream_protocol::socket & {
   return socket_;
 }
 
-void PipeTransport::RemoveExistingSocketFile() {
-  try {
-    // Check if the socket file exists and remove it if it does
-    if (std::filesystem::exists(socket_path_)) {
-      std::filesystem::remove(socket_path_);
-      spdlog::debug("Removed existing socket file: {}", socket_path_);
+auto PipeTransport::RemoveExistingSocketFile()
+    -> std::expected<void, error::RpcError> {
+  std::error_code ec;
+  if (std::filesystem::exists(socket_path_, ec)) {
+    if (ec) {
+      return std::unexpected(error::CreateTransportError(
+          "Error checking if socket file exists: " + ec.message()));
     }
-  } catch (const std::exception &e) {
-    spdlog::error("Error removing socket file: {}", e.what());
-    throw;
+    std::filesystem::remove(socket_path_, ec);
+    if (ec) {
+      return std::unexpected(error::CreateTransportError(
+          "Error removing socket file: " + ec.message()));
+    }
+    spdlog::debug("Removed existing socket file: {}", socket_path_);
+  } else {
+    spdlog::debug("No existing socket file to remove: {}", socket_path_);
   }
+  return {};
 }
 
 auto PipeTransport::SendMessage(std::string message) -> asio::awaitable<void> {
@@ -273,83 +283,85 @@ auto PipeTransport::Close() -> asio::awaitable<void> {
   }
 }
 
-auto PipeTransport::Connect() -> asio::awaitable<void> {
+auto PipeTransport::Connect()
+    -> asio::awaitable<std::expected<void, error::RpcError>> {
   spdlog::debug("Connecting to {}", socket_path_);
 
   // Make sure we're not already connected
   if (is_connected_) {
-    co_return;
+    co_return std::expected<void, error::RpcError>();
   }
 
-  try {
-    // Check if we're closed
-    if (is_closed_) {
-      throw std::runtime_error("Cannot connect a closed transport");
-    }
-
-    // Close any existing socket
-    if (socket_.is_open()) {
-      asio::error_code ec;
-      socket_.close(ec);
-      if (ec) {
-        spdlog::warn("Error closing socket before reconnect: {}", ec.message());
-      }
-    }
-
-    // Create a new socket if needed
-    if (!socket_.is_open()) {
-      socket_ = asio::local::stream_protocol::socket(GetExecutor());
-    }
-
-    // Create the endpoint and connect
-    asio::local::stream_protocol::endpoint endpoint(socket_path_);
-    co_await socket_.async_connect(endpoint, asio::use_awaitable);
-
-    // Set connected flag only after successful connection
-    is_connected_ = true;
-    spdlog::debug("Connected to {}", socket_path_);
-  } catch (const std::exception &e) {
-    spdlog::error("Error connecting to {}: {}", socket_path_, e.what());
-
-    // Reset socket to clean state
-    try {
-      if (socket_.is_open()) {
-        asio::error_code ec;
-        socket_.close(ec);
-      }
-    } catch (...) {
-      // Ignore errors during cleanup
-    }
-
-    throw;
+  // Check if we're closed
+  if (is_closed_) {
+    co_return std::unexpected(
+        error::CreateTransportError("Cannot connect a closed transport"));
   }
+
+  // Close any existing socket
+  std::error_code ec;
+  if (socket_.is_open()) {
+    socket_.close(ec);
+    if (ec) {
+      spdlog::warn("Error closing socket before reconnect: {}", ec.message());
+    }
+  }
+
+  // Create a new socket
+  socket_ = asio::local::stream_protocol::socket(GetExecutor());
+
+  // Create the endpoint and connect
+  asio::local::stream_protocol::endpoint endpoint(socket_path_);
+  co_await socket_.async_connect(endpoint, asio::use_awaitable);
+
+  is_connected_ = true;
+  spdlog::debug("Connected to {}", socket_path_);
+
+  co_return std::expected<void, error::RpcError>();
 }
 
-auto PipeTransport::BindAndListen() -> asio::awaitable<void> {
+auto PipeTransport::BindAndListen()
+    -> asio::awaitable<std::expected<void, error::RpcError>> {
   spdlog::debug("Binding to {}", socket_path_);
 
-  try {
-    // Remove any existing socket file
-    RemoveExistingSocketFile();
-
-    // Create the endpoint
-    asio::local::stream_protocol::endpoint endpoint(socket_path_);
-
-    // Open and bind the acceptor
-    acceptor_->open();
-    acceptor_->bind(endpoint);
-    acceptor_->listen();
-
-    spdlog::debug("Listening on {}", socket_path_);
-
-    // Accept a connection
-    co_await acceptor_->async_accept(socket_, asio::use_awaitable);
-    is_connected_ = true;
-    spdlog::debug("Accepted connection on {}", socket_path_);
-  } catch (const std::exception &e) {
-    spdlog::error("Error binding/listening on {}: {}", socket_path_, e.what());
-    throw;
+  auto result = RemoveExistingSocketFile();
+  if (!result) {
+    spdlog::error(
+        "Error removing existing socket file: {}", result.error().message);
+    co_return std::unexpected(result.error());
   }
+
+  // Create the endpoint
+  asio::local::stream_protocol::endpoint endpoint(socket_path_);
+
+  // Open and bind the acceptor
+  std::error_code ec;
+  acceptor_->open(endpoint.protocol(), ec);
+  if (ec) {
+    spdlog::error("Error opening acceptor: {}", ec.message());
+    co_return std::unexpected(
+        error::CreateTransportError("Error opening acceptor: " + ec.message()));
+  }
+  acceptor_->bind(endpoint, ec);
+  if (ec) {
+    spdlog::error("Error binding acceptor: {}", ec.message());
+    co_return std::unexpected(
+        error::CreateTransportError("Error binding acceptor: " + ec.message()));
+  }
+  acceptor_->listen(asio::socket_base::max_listen_connections, ec);
+  if (ec) {
+    spdlog::error("Error listening on acceptor: {}", ec.message());
+    co_return std::unexpected(error::CreateTransportError(
+        "Error listening on acceptor: " + ec.message()));
+  }
+
+  // Accept a connection
+  spdlog::debug("Waiting for connection on {}", socket_path_);
+  co_await acceptor_->async_accept(socket_, asio::use_awaitable);
+  is_connected_ = true;
+  spdlog::debug("Accepted connection on {}", socket_path_);
+
+  co_return std::expected<void, error::RpcError>();
 }
 
 }  // namespace jsonrpc::transport

--- a/src/transport/pipe_transport.cpp
+++ b/src/transport/pipe_transport.cpp
@@ -237,57 +237,57 @@ auto PipeTransport::SendMessage(std::string message)
   co_return std::expected<void, error::RpcError>{};
 }
 
-auto PipeTransport::ReceiveMessage() -> asio::awaitable<std::string> {
-  try {
-    co_await asio::post(GetStrand(), asio::use_awaitable);
+auto PipeTransport::ReceiveMessage()
+    -> asio::awaitable<std::expected<std::string, error::RpcError>> {
+  co_await asio::post(GetStrand(), asio::use_awaitable);
 
-    if (is_closed_) {
-      spdlog::warn("ReceiveMessage called after transport was closed");
-      co_return std::string();
-    }
+  if (is_closed_) {
+    spdlog::warn("ReceiveMessage called after transport was closed");
+    co_return std::unexpected(error::CreateTransportError(
+        "ReceiveMessage called after transport was closed"));
+  }
 
-    if (!is_started_) {
-      throw std::runtime_error(
-          "Transport not started before receiving message");
-    }
+  if (!is_started_) {
+    co_return std::unexpected(error::CreateTransportError(
+        "Transport not started before receiving message"));
+  }
 
-    if (!socket_.is_open()) {
-      spdlog::warn("ReceiveMessage called on a closed socket");
-      co_return std::string();
-    }
+  if (!socket_.is_open()) {
+    spdlog::warn("ReceiveMessage called on a closed socket");
+    co_return std::unexpected(error::CreateTransportError(
+        "ReceiveMessage called on a closed socket"));
+  }
 
-    // Clear any existing message buffer
-    message_buffer_.clear();
+  message_buffer_.clear();
 
-    // Read data from socket
-    std::size_t bytes_read = co_await socket_.async_read_some(
-        asio::buffer(read_buffer_), asio::use_awaitable);
+  std::error_code ec;
+  std::size_t bytes_read = co_await socket_.async_read_some(
+      asio::buffer(read_buffer_),
+      asio::redirect_error(asio::use_awaitable, ec));
 
-    if (bytes_read == 0) {
-      if (is_closed_) {
-        co_return std::string();
-      }
-      throw std::runtime_error("Connection closed by peer");
-    }
-
-    message_buffer_.append(read_buffer_.data(), bytes_read);
-    spdlog::debug("Received message: {}", message_buffer_);
-    co_return std::move(message_buffer_);
-  } catch (const asio::system_error &e) {
-    // Handle ASIO-specific errors
-    if (e.code() == asio::error::eof) {
+  if (ec) {
+    if (ec == asio::error::eof) {
       spdlog::debug("Connection closed by peer (EOF)");
       is_connected_ = false;
-    } else if (e.code() == asio::error::operation_aborted) {
+      co_return std::unexpected(
+          error::CreateTransportError("Connection closed by peer"));
+    } else if (ec == asio::error::operation_aborted) {
       spdlog::debug("Receive operation aborted");
+      co_return std::unexpected(error::CreateTransportError("Receive aborted"));
     } else {
-      spdlog::error("ASIO error receiving message: {}", e.what());
+      spdlog::error("Error receiving message: {}", ec.message());
+      co_return std::unexpected(
+          error::CreateTransportError("Receive error: " + ec.message()));
     }
-    throw;
-  } catch (const std::exception &e) {
-    spdlog::error("Error receiving message: {}", e.what());
-    throw;
   }
+
+  if (bytes_read == 0) {
+    co_return std::unexpected(error::CreateTransportError("No data received"));
+  }
+
+  message_buffer_.append(read_buffer_.data(), bytes_read);
+  spdlog::debug("Received message: {}", message_buffer_);
+  co_return std::move(message_buffer_);
 }
 
 auto PipeTransport::Connect()

--- a/src/transport/pipe_transport.cpp
+++ b/src/transport/pipe_transport.cpp
@@ -324,7 +324,12 @@ auto PipeTransport::Connect()
 
   // Create the endpoint and connect
   asio::local::stream_protocol::endpoint endpoint(socket_path_);
-  co_await socket_.async_connect(endpoint, asio::use_awaitable);
+  co_await socket_.async_connect(
+      endpoint, asio::redirect_error(asio::use_awaitable, ec));
+  if (ec) {
+    spdlog::error("Error connecting to {}: {}", socket_path_, ec.message());
+    co_return std::unexpected(error::CreateTransportError(ec.message()));
+  }
 
   is_connected_ = true;
   spdlog::debug("Connected to {}", socket_path_);
@@ -369,7 +374,12 @@ auto PipeTransport::BindAndListen()
 
   // Accept a connection
   spdlog::debug("Waiting for connection on {}", socket_path_);
-  co_await acceptor_->async_accept(socket_, asio::use_awaitable);
+  co_await acceptor_->async_accept(
+      socket_, asio::redirect_error(asio::use_awaitable, ec));
+  if (ec) {
+    spdlog::error("Error accepting connection: {}", ec.message());
+    co_return std::unexpected(error::CreateTransportError(ec.message()));
+  }
   is_connected_ = true;
   spdlog::debug("Accepted connection on {}", socket_path_);
 

--- a/src/transport/pipe_transport.cpp
+++ b/src/transport/pipe_transport.cpp
@@ -17,16 +17,6 @@ PipeTransport::PipeTransport(
       socket_path_(std::move(socket_path)),
       is_server_(is_server),
       read_buffer_() {
-  spdlog::debug(
-      "PipeTransport initialized ({}): {}", is_server_ ? "server" : "client",
-      socket_path_);
-
-  // Create acceptor in constructor if this is a server, but don't bind yet
-  if (is_server_) {
-    acceptor_ =
-        std::make_shared<asio::local::stream_protocol::acceptor>(GetExecutor());
-  }
-  // Connections will be established in the Start() method
 }
 
 PipeTransport::~PipeTransport() {
@@ -346,6 +336,12 @@ auto PipeTransport::BindAndListen()
     spdlog::error(
         "Error removing existing socket file: {}", result.error().message);
     co_return std::unexpected(result.error());
+  }
+
+  // Lazily construct the acceptor if not already created
+  if (!acceptor_) {
+    acceptor_ =
+        std::make_unique<asio::local::stream_protocol::acceptor>(GetExecutor());
   }
 
   // Create the endpoint

--- a/src/transport/pipe_transport.cpp
+++ b/src/transport/pipe_transport.cpp
@@ -133,45 +133,61 @@ auto PipeTransport::Close()
 }
 
 void PipeTransport::CloseNow() {
-  // Set the closed flag to prevent concurrent operations
   is_closed_ = true;
   is_connected_ = false;
 
-  try {
-    // Cancel and close the socket synchronously
-    if (socket_.is_open()) {
-      spdlog::debug("Closing socket synchronously");
-      socket_.cancel();
-      asio::error_code ec;
-      socket_.close(ec);
-      if (ec) {
-        spdlog::warn("Error closing socket: {}", ec.message());
-      }
+  auto try_close_socket = [&]() {
+    if (!socket_.is_open()) {
+      return;
+    }
+    spdlog::debug("Closing socket synchronously");
+
+    std::error_code ec;
+    socket_.cancel();
+    socket_.close(ec);
+    if (ec) {
+      spdlog::warn("Error closing socket: {}", ec.message());
+    }
+  };
+
+  auto try_close_acceptor = [&]() {
+    if (!is_server_ || !acceptor_ || !acceptor_->is_open()) {
+      return;
+    }
+    spdlog::debug("Closing acceptor synchronously");
+
+    std::error_code ec;
+    acceptor_->cancel();
+    acceptor_->close(ec);
+    if (ec) {
+      spdlog::warn("Error closing acceptor: {}", ec.message());
+    }
+  };
+
+  auto try_remove_socket_file = [&]() {
+    if (!is_server_ || socket_path_.empty()) {
+      return;
     }
 
-    // Cancel and close the acceptor safely
-    if (is_server_ && acceptor_ && acceptor_->is_open()) {
-      spdlog::debug("Closing acceptor synchronously");
-      acceptor_->cancel();
-      asio::error_code ec;
-      acceptor_->close(ec);
+    std::error_code ec;
+    if (std::filesystem::exists(socket_path_, ec) && !ec) {
+      std::filesystem::remove(socket_path_, ec);
       if (ec) {
-        spdlog::warn("Error closing acceptor: {}", ec.message());
-      }
-    }
-
-    // Clean up the socket file
-    if (is_server_ && !socket_path_.empty() &&
-        std::filesystem::exists(socket_path_)) {
-      try {
-        std::filesystem::remove(socket_path_);
+        spdlog::warn("Error removing socket file: {}", ec.message());
+      } else {
         spdlog::debug("Removed socket file: {}", socket_path_);
-      } catch (const std::exception &e) {
-        spdlog::warn("Error removing socket file: {}", e.what());
       }
+    } else if (ec) {
+      spdlog::warn("Error checking socket file existence: {}", ec.message());
     }
+  };
+
+  try {
+    try_close_socket();
+    try_close_acceptor();
+    try_remove_socket_file();
   } catch (const std::exception &e) {
-    spdlog::error("Error in synchronous close: {}", e.what());
+    spdlog::error("Unexpected exception during CloseNow(): {}", e.what());
   }
 }
 

--- a/src/transport/pipe_transport.cpp
+++ b/src/transport/pipe_transport.cpp
@@ -205,31 +205,36 @@ auto PipeTransport::RemoveExistingSocketFile()
   return {};
 }
 
-auto PipeTransport::SendMessage(std::string message) -> asio::awaitable<void> {
-  try {
-    co_await asio::post(GetStrand(), asio::use_awaitable);
+auto PipeTransport::SendMessage(std::string message)
+    -> asio::awaitable<std::expected<void, error::RpcError>> {
+  co_await asio::post(GetStrand(), asio::use_awaitable);
 
-    if (is_closed_) {
-      throw std::runtime_error("Attempt to send message on closed transport");
-    }
-
-    // Ensure transport is started
-    if (!is_started_) {
-      throw std::runtime_error("Transport not started before sending message");
-    }
-
-    // No lazy connection - Start() should have connected if needed
-    if (!socket_.is_open()) {
-      throw std::runtime_error("Socket not open");
-    }
-
-    // Send the message
-    co_await asio::async_write(
-        socket_, asio::buffer(message), asio::use_awaitable);
-  } catch (const std::exception &e) {
-    spdlog::error("Error sending message: {}", e.what());
-    throw;
+  if (is_closed_) {
+    co_return std::unexpected(error::CreateTransportError(
+        "Attempt to send message on closed transport"));
   }
+
+  if (!is_started_) {
+    co_return std::unexpected(error::CreateTransportError(
+        "Transport not started before sending message"));
+  }
+
+  if (!socket_.is_open()) {
+    co_return std::unexpected(error::CreateTransportError("Socket not open"));
+  }
+
+  // Write to the socket with error redirection
+  std::error_code ec;
+  co_await asio::async_write(
+      socket_, asio::buffer(message),
+      asio::redirect_error(asio::use_awaitable, ec));
+  if (ec) {
+    spdlog::error("Error sending message: {}", ec.message());
+    co_return std::unexpected(
+        error::CreateTransportError("Error sending message: " + ec.message()));
+  }
+
+  co_return std::expected<void, error::RpcError>{};
 }
 
 auto PipeTransport::ReceiveMessage() -> asio::awaitable<std::string> {

--- a/src/transport/pipe_transport.cpp
+++ b/src/transport/pipe_transport.cpp
@@ -85,41 +85,45 @@ void PipeTransport::CloseNow() {
 
 auto PipeTransport::Start()
     -> asio::awaitable<std::expected<void, error::RpcError>> {
-  try {
-    co_await asio::post(GetStrand(), asio::use_awaitable);
+  co_await asio::post(GetStrand(), asio::use_awaitable);
 
-    if (is_started_) {
-      spdlog::debug("PipeTransport already started");
-      co_return std::unexpected(
-          error::CreateTransportError("PipeTransport already started"));
-    }
-
-    if (is_closed_) {
-      spdlog::error("Cannot start a closed transport");
-      co_return std::unexpected(
-          error::CreateTransportError("Cannot start a closed transport"));
-    }
-
-    // Set started flag before performing operations
-    is_started_ = true;
-
-    if (is_server_) {
-      // For server, bind and listen for connections
-      spdlog::info("Starting PipeTransport server at {}", socket_path_);
-      co_await BindAndListen();
-    } else {
-      // For client, connect to the server
-      spdlog::info("Connecting PipeTransport client to {}", socket_path_);
-      co_await Connect();
-      spdlog::debug("PipeTransport client connected to {}", socket_path_);
-    }
-
-    co_return std::expected<void, error::RpcError>();
-  } catch (const std::exception &e) {
-    spdlog::error("Error in PipeTransport::Start(): {}", e.what());
-    is_started_ = false;
-    throw;
+  if (is_started_) {
+    spdlog::debug("PipeTransport already started");
+    co_return std::unexpected(
+        error::CreateTransportError("PipeTransport already started"));
   }
+
+  if (is_closed_) {
+    spdlog::error("Cannot start a closed transport");
+    co_return std::unexpected(
+        error::CreateTransportError("Cannot start a closed transport"));
+  }
+
+  if (is_server_) {
+    // For server, bind and listen for connections
+    spdlog::info("Starting PipeTransport server at {}", socket_path_);
+    auto result = co_await BindAndListen();
+    if (!result) {
+      spdlog::error(
+          "Error starting PipeTransport server: {}", result.error().message);
+      co_return std::unexpected(result.error());
+    }
+  } else {
+    // For client, connect to the server
+    spdlog::info("Connecting PipeTransport client to {}", socket_path_);
+    auto result = co_await Connect();
+    if (!result) {
+      spdlog::error(
+          "Error connecting PipeTransport client: {}", result.error().message);
+      co_return std::unexpected(result.error());
+    }
+    spdlog::debug("PipeTransport client connected to {}", socket_path_);
+  }
+
+  // Set started flag before performing operations
+  is_started_ = true;
+  spdlog::debug("PipeTransport successfully started");
+  co_return std::expected<void, error::RpcError>();
 }
 
 auto PipeTransport::GetSocket() -> asio::local::stream_protocol::socket & {

--- a/src/transport/socket_transport.cpp
+++ b/src/transport/socket_transport.cpp
@@ -160,28 +160,35 @@ auto SocketTransport::GetSocket() -> asio::ip::tcp::socket & {
 }
 
 auto SocketTransport::SendMessage(std::string message)
-    -> asio::awaitable<void> {
-  try {
-    co_await asio::post(GetStrand(), asio::use_awaitable);
+    -> asio::awaitable<std::expected<void, error::RpcError>> {
+  co_await asio::post(GetStrand(), asio::use_awaitable);
 
-    if (is_closed_) {
-      throw std::runtime_error("SendMessage() called on closed transport");
-    }
-
-    if (!is_started_) {
-      throw std::runtime_error("Transport not started before sending message");
-    }
-
-    if (!socket_.is_open()) {
-      throw std::runtime_error("Socket not open in SendMessage()");
-    }
-
-    co_await asio::async_write(
-        socket_, asio::buffer(message), asio::use_awaitable);
-  } catch (const std::exception &e) {
-    spdlog::error("Exception in SendMessage(): {}", e.what());
-    throw;
+  if (is_closed_) {
+    co_return std::unexpected(error::CreateTransportError(
+        "SendMessage() called on closed transport"));
   }
+
+  if (!is_started_) {
+    co_return std::unexpected(error::CreateTransportError(
+        "Transport not started before sending message"));
+  }
+
+  if (!socket_.is_open()) {
+    co_return std::unexpected(
+        error::CreateTransportError("Socket not open in SendMessage()"));
+  }
+
+  std::error_code ec;
+  co_await asio::async_write(
+      socket_, asio::buffer(message),
+      asio::redirect_error(asio::use_awaitable, ec));
+  if (ec) {
+    spdlog::error("SendMessage failed: {}", ec.message());
+    co_return std::unexpected(
+        error::CreateTransportError("Error sending message: " + ec.message()));
+  }
+
+  co_return std::expected<void, error::RpcError>{};
 }
 
 auto SocketTransport::ReceiveMessage() -> asio::awaitable<std::string> {

--- a/src/transport/socket_transport.cpp
+++ b/src/transport/socket_transport.cpp
@@ -46,7 +46,7 @@ auto SocketTransport::Start()
   std::expected<void, error::RpcError> result;
 
   if (is_server_) {
-    spdlog::info("Starting SocketTransport server at {}:{}", address_, port_);
+    spdlog::debug("Starting SocketTransport server at {}:{}", address_, port_);
     result = co_await BindAndListen();
     if (!result) {
       spdlog::error(
@@ -54,7 +54,8 @@ auto SocketTransport::Start()
       co_return std::unexpected(result.error());
     }
   } else {
-    spdlog::info("Connecting SocketTransport client to {}:{}", address_, port_);
+    spdlog::debug(
+        "Connecting SocketTransport client to {}:{}", address_, port_);
     result = co_await Connect();
     if (!result) {
       spdlog::error(

--- a/src/transport/socket_transport.cpp
+++ b/src/transport/socket_transport.cpp
@@ -16,19 +16,16 @@ SocketTransport::SocketTransport(
       port_(port),
       is_server_(is_server),
       read_buffer_() {
-  spdlog::debug(
-      "SocketTransport initialized ({}): {}:{}",
-      is_server_ ? "server" : "client", address_, port_);
 }
 
 SocketTransport::~SocketTransport() {
-  try {
-    // If we haven't closed explicitly, do it now synchronously
-    if (!is_closed_) {
+  if (!is_closed_) {
+    spdlog::debug("SocketTransport destructor triggering CloseNow()");
+    try {
       CloseNow();
+    } catch (const std::exception &e) {
+      spdlog::error("Error in SocketTransport destructor: {}", e.what());
     }
-  } catch (const std::exception &e) {
-    spdlog::error("Error in SocketTransport destructor: {}", e.what());
   }
 }
 

--- a/src/transport/socket_transport.cpp
+++ b/src/transport/socket_transport.cpp
@@ -53,18 +53,21 @@ void SocketTransport::CloseNow() {
   }
 }
 
-auto SocketTransport::Start() -> asio::awaitable<void> {
+auto SocketTransport::Start()
+    -> asio::awaitable<std::expected<void, error::RpcError>> {
   try {
     co_await asio::post(GetStrand(), asio::use_awaitable);
 
     if (is_started_) {
       spdlog::debug("SocketTransport already started");
-      co_return;
+      co_return std::unexpected(
+          error::CreateTransportError("SocketTransport already started"));
     }
 
     if (is_closed_) {
       spdlog::error("Cannot start a closed transport");
-      throw std::runtime_error("Cannot start a closed transport");
+      co_return std::unexpected(
+          error::CreateTransportError("Cannot start a closed transport"));
     }
 
     // Set started flag before performing operations
@@ -83,7 +86,7 @@ auto SocketTransport::Start() -> asio::awaitable<void> {
           "SocketTransport client connected to {}:{}", address_, port_);
     }
 
-    co_return;
+    co_return std::expected<void, error::RpcError>();
   } catch (const std::exception &e) {
     spdlog::error("Error in Start(): {}", e.what());
     is_started_ = false;

--- a/src/transport/socket_transport.cpp
+++ b/src/transport/socket_transport.cpp
@@ -177,12 +177,14 @@ auto SocketTransport::ReceiveMessage() -> asio::awaitable<std::string> {
   }
 }
 
-auto SocketTransport::Close() -> asio::awaitable<void> {
+auto SocketTransport::Close()
+    -> asio::awaitable<std::expected<void, error::RpcError>> {
   try {
     co_await asio::post(GetStrand(), asio::use_awaitable);
 
     if (is_closed_) {
-      co_return;  // Already closed
+      spdlog::debug("SocketTransport already closed");
+      co_return std::expected<void, error::RpcError>();
     }
 
     is_closed_ = true;
@@ -205,7 +207,7 @@ auto SocketTransport::Close() -> asio::awaitable<void> {
     // to the strand complete
     co_await asio::post(GetStrand(), asio::use_awaitable);
 
-    co_return;
+    co_return std::expected<void, error::RpcError>();
   } catch (const std::exception &e) {
     spdlog::error("Error closing socket transport: {}", e.what());
     throw;

--- a/src/transport/socket_transport.cpp
+++ b/src/transport/socket_transport.cpp
@@ -1,7 +1,5 @@
 #include "jsonrpc/transport/socket_transport.hpp"
 
-#include <stdexcept>
-
 #include <asio.hpp>
 #include <spdlog/spdlog.h>
 
@@ -191,58 +189,59 @@ auto SocketTransport::SendMessage(std::string message)
   co_return std::expected<void, error::RpcError>{};
 }
 
-auto SocketTransport::ReceiveMessage() -> asio::awaitable<std::string> {
-  try {
-    co_await asio::post(GetStrand(), asio::use_awaitable);
+auto SocketTransport::ReceiveMessage()
+    -> asio::awaitable<std::expected<std::string, error::RpcError>> {
+  co_await asio::post(GetStrand(), asio::use_awaitable);
 
-    if (is_closed_) {
-      spdlog::warn("ReceiveMessage() called after transport was closed");
-      co_return std::string();
-    }
+  if (is_closed_) {
+    spdlog::warn("ReceiveMessage() called after transport was closed");
+    co_return std::unexpected(error::CreateTransportError(
+        "ReceiveMessage() called after transport was closed"));
+  }
 
-    if (!is_started_) {
-      throw std::runtime_error(
-          "Transport not started before receiving message");
-    }
+  if (!is_started_) {
+    co_return std::unexpected(error::CreateTransportError(
+        "Transport not started before receiving message"));
+  }
 
-    if (!socket_.is_open()) {
-      spdlog::warn("Socket not open in ReceiveMessage()");
-      co_return std::string();
-    }
+  if (!socket_.is_open()) {
+    spdlog::warn("Socket not open in ReceiveMessage()");
+    co_return std::unexpected(
+        error::CreateTransportError("Socket not open in ReceiveMessage()"));
+  }
 
-    // Clear any existing message buffer
-    message_buffer_.clear();
+  message_buffer_.clear();
 
-    // Read data from socket
-    size_t bytes_read = co_await socket_.async_read_some(
-        asio::buffer(read_buffer_), asio::use_awaitable);
+  std::error_code ec;
+  size_t bytes_read = co_await socket_.async_read_some(
+      asio::buffer(read_buffer_),
+      asio::redirect_error(asio::use_awaitable, ec));
 
-    if (bytes_read == 0) {
-      if (is_closed_) {
-        co_return std::string();
-      }
-      throw std::runtime_error("Connection closed by peer");
-    }
-
-    message_buffer_.append(read_buffer_.data(), bytes_read);
-    spdlog::debug("Received {} bytes", bytes_read);
-
-    co_return std::move(message_buffer_);
-  } catch (const asio::system_error &e) {
-    // Handle ASIO-specific errors
-    if (e.code() == asio::error::eof) {
+  if (ec) {
+    if (ec == asio::error::eof) {
       spdlog::debug("EOF received, connection closed by peer");
       is_connected_ = false;
-    } else if (e.code() == asio::error::operation_aborted) {
+      co_return std::unexpected(
+          error::CreateTransportError("Connection closed by peer"));
+    } else if (ec == asio::error::operation_aborted) {
       spdlog::debug("Read operation aborted");
+      co_return std::unexpected(
+          error::CreateTransportError("Receive operation aborted"));
     } else {
-      spdlog::error("ASIO error in ReceiveMessage(): {}", e.what());
+      spdlog::error("ASIO error in ReceiveMessage(): {}", ec.message());
+      co_return std::unexpected(
+          error::CreateTransportError("Receive error: " + ec.message()));
     }
-    throw;
-  } catch (const std::exception &e) {
-    spdlog::error("Exception in ReceiveMessage(): {}", e.what());
-    throw;
   }
+
+  if (bytes_read == 0) {
+    co_return std::unexpected(
+        error::CreateTransportError("Connection closed by peer (no data)"));
+  }
+
+  message_buffer_.append(read_buffer_.data(), bytes_read);
+  spdlog::debug("Received {} bytes", bytes_read);
+  co_return std::move(message_buffer_);
 }
 
 auto SocketTransport::Connect()

--- a/src/transport/socket_transport.cpp
+++ b/src/transport/socket_transport.cpp
@@ -32,27 +32,6 @@ SocketTransport::~SocketTransport() {
   }
 }
 
-void SocketTransport::CloseNow() {
-  // Set closed flag to prevent concurrent operations
-  is_closed_ = true;
-  is_connected_ = false;
-
-  try {
-    // Cancel and close the socket synchronously
-    if (socket_.is_open()) {
-      spdlog::debug("Closing socket synchronously");
-      socket_.cancel();
-      asio::error_code ec;
-      socket_.close(ec);
-      if (ec) {
-        spdlog::warn("Error closing socket: {}", ec.message());
-      }
-    }
-  } catch (const std::exception &e) {
-    spdlog::error("Error in synchronous close: {}", e.what());
-  }
-}
-
 auto SocketTransport::Start()
     -> asio::awaitable<std::expected<void, error::RpcError>> {
   try {
@@ -91,6 +70,64 @@ auto SocketTransport::Start()
     spdlog::error("Error in Start(): {}", e.what());
     is_started_ = false;
     throw;
+  }
+}
+
+auto SocketTransport::Close()
+    -> asio::awaitable<std::expected<void, error::RpcError>> {
+  try {
+    co_await asio::post(GetStrand(), asio::use_awaitable);
+
+    if (is_closed_) {
+      spdlog::debug("SocketTransport already closed");
+      co_return std::expected<void, error::RpcError>();
+    }
+
+    is_closed_ = true;
+    is_connected_ = false;
+
+    spdlog::debug("Closing socket transport");
+
+    // Cancel and close the socket safely
+    if (socket_.is_open()) {
+      spdlog::debug("Closing socket");
+      socket_.cancel();
+      asio::error_code ec;
+      socket_.close(ec);
+      if (ec) {
+        spdlog::warn("Error closing socket: {}", ec.message());
+      }
+    }
+
+    // Add an additional synchronization point to ensure all operations posted
+    // to the strand complete
+    co_await asio::post(GetStrand(), asio::use_awaitable);
+
+    co_return std::expected<void, error::RpcError>();
+  } catch (const std::exception &e) {
+    spdlog::error("Error closing socket transport: {}", e.what());
+    throw;
+  }
+}
+
+void SocketTransport::CloseNow() {
+  // Set closed flag to prevent concurrent operations
+  is_closed_ = true;
+  is_connected_ = false;
+
+  try {
+    // Cancel and close the socket synchronously
+    if (socket_.is_open()) {
+      spdlog::debug("Closing socket synchronously");
+      socket_.cancel();
+      asio::error_code ec;
+      socket_.close(ec);
+      if (ec) {
+        spdlog::warn("Error closing socket: {}", ec.message());
+      }
+    }
+  } catch (const std::exception &e) {
+    spdlog::error("Error in synchronous close: {}", e.what());
   }
 }
 
@@ -177,130 +214,129 @@ auto SocketTransport::ReceiveMessage() -> asio::awaitable<std::string> {
   }
 }
 
-auto SocketTransport::Close()
+auto SocketTransport::Connect()
     -> asio::awaitable<std::expected<void, error::RpcError>> {
-  try {
-    co_await asio::post(GetStrand(), asio::use_awaitable);
-
-    if (is_closed_) {
-      spdlog::debug("SocketTransport already closed");
-      co_return std::expected<void, error::RpcError>();
-    }
-
-    is_closed_ = true;
-    is_connected_ = false;
-
-    spdlog::debug("Closing socket transport");
-
-    // Cancel and close the socket safely
-    if (socket_.is_open()) {
-      spdlog::debug("Closing socket");
-      socket_.cancel();
-      asio::error_code ec;
-      socket_.close(ec);
-      if (ec) {
-        spdlog::warn("Error closing socket: {}", ec.message());
-      }
-    }
-
-    // Add an additional synchronization point to ensure all operations posted
-    // to the strand complete
-    co_await asio::post(GetStrand(), asio::use_awaitable);
-
-    co_return std::expected<void, error::RpcError>();
-  } catch (const std::exception &e) {
-    spdlog::error("Error closing socket transport: {}", e.what());
-    throw;
-  }
-}
-
-auto SocketTransport::Connect() -> asio::awaitable<void> {
   spdlog::debug("Connecting to {}:{}", address_, port_);
 
-  // Make sure we're not already connected
   if (is_connected_) {
-    co_return;
+    co_return std::expected<void, error::RpcError>{};
   }
 
-  try {
-    // Check if we're closed
-    if (is_closed_) {
-      throw std::runtime_error("Cannot connect a closed transport");
-    }
-
-    // Close any existing socket
-    if (socket_.is_open()) {
-      asio::error_code ec;
-      socket_.close(ec);
-      if (ec) {
-        spdlog::warn("Error closing socket before reconnect: {}", ec.message());
-      }
-    }
-
-    // Create a new socket if needed
-    if (!socket_.is_open()) {
-      socket_ = asio::ip::tcp::socket(GetExecutor());
-    }
-
-    // Resolve the endpoint
-    asio::ip::tcp::resolver resolver(GetExecutor());
-    auto endpoints = co_await resolver.async_resolve(
-        address_, std::to_string(port_), asio::use_awaitable);
-
-    // Connect to the first endpoint
-    co_await asio::async_connect(socket_, endpoints, asio::use_awaitable);
-
-    // Set connected flag only after successful connection
-    is_connected_ = true;
-    spdlog::debug("Connected to {}:{}", address_, port_);
-  } catch (const std::exception &e) {
-    spdlog::error("Error connecting to {}:{}: {}", address_, port_, e.what());
-
-    // Reset socket to clean state
-    try {
-      if (socket_.is_open()) {
-        asio::error_code ec;
-        socket_.close(ec);
-      }
-    } catch (...) {
-      // Ignore errors during cleanup
-    }
-
-    throw;
+  if (is_closed_) {
+    co_return std::unexpected(
+        error::CreateTransportError("Cannot connect a closed transport"));
   }
+
+  // Close any existing socket
+  asio::error_code ec;
+  if (socket_.is_open()) {
+    socket_.close(ec);
+    if (ec) {
+      spdlog::warn("Error closing socket before reconnect: {}", ec.message());
+    }
+  }
+
+  // Create new socket if needed
+  if (!socket_.is_open()) {
+    socket_ = asio::ip::tcp::socket(GetExecutor());
+  }
+
+  // Resolve address
+  asio::ip::tcp::resolver resolver(GetExecutor());
+  auto endpoints = co_await resolver.async_resolve(
+      address_, std::to_string(port_),
+      asio::redirect_error(asio::use_awaitable, ec));
+  if (ec) {
+    spdlog::error("Error resolving {}:{}: {}", address_, port_, ec.message());
+    co_return std::unexpected(
+        error::CreateTransportError("Resolve error: " + ec.message()));
+  }
+
+  // Connect
+  co_await asio::async_connect(
+      socket_, endpoints, asio::redirect_error(asio::use_awaitable, ec));
+  if (ec) {
+    spdlog::error(
+        "Error connecting to {}:{}: {}", address_, port_, ec.message());
+    socket_.close();  // cleanup
+    co_return std::unexpected(
+        error::CreateTransportError("Connect error: " + ec.message()));
+  }
+
+  is_connected_ = true;
+  spdlog::debug("Connected to {}:{}", address_, port_);
+  co_return std::expected<void, error::RpcError>{};
 }
 
-auto SocketTransport::BindAndListen() -> asio::awaitable<void> {
+auto SocketTransport::BindAndListen()
+    -> asio::awaitable<std::expected<void, error::RpcError>> {
   spdlog::debug("Binding to {}:{}", address_, port_);
 
-  try {
-    // Create the endpoint
-    asio::ip::tcp::endpoint endpoint(asio::ip::tcp::v4(), port_);
+  asio::error_code ec;
 
-    // For specific address binding
-    if (address_ != "0.0.0.0" && address_ != "::") {
-      asio::ip::tcp::resolver resolver(GetExecutor());
-      auto results = co_await resolver.async_resolve(
-          address_, std::to_string(port_), asio::use_awaitable);
-      endpoint = *results.begin();
+  // Create the endpoint
+  asio::ip::tcp::endpoint endpoint(asio::ip::tcp::v4(), port_);
+
+  // Resolve specific address if not 0.0.0.0 / ::
+  if (address_ != "0.0.0.0" && address_ != "::") {
+    asio::ip::tcp::resolver resolver(GetExecutor());
+    auto results = co_await resolver.async_resolve(
+        address_, std::to_string(port_),
+        asio::redirect_error(asio::use_awaitable, ec));
+    if (ec) {
+      spdlog::error("Error resolving {}:{}: {}", address_, port_, ec.message());
+      co_return std::unexpected(
+          error::CreateTransportError("Resolve error: " + ec.message()));
     }
-
-    // Create an acceptor
-    asio::ip::tcp::acceptor acceptor(GetExecutor(), endpoint);
-    acceptor.set_option(asio::ip::tcp::acceptor::reuse_address(true));
-
-    spdlog::debug("Listening on {}:{}", address_, port_);
-
-    // Accept a connection
-    co_await acceptor.async_accept(socket_, asio::use_awaitable);
-    is_connected_ = true;
-
-    spdlog::debug("Accepted connection on {}:{}", address_, port_);
-  } catch (const std::exception &e) {
-    spdlog::error(
-        "Error binding/listening on {}:{}: {}", address_, port_, e.what());
-    throw;
+    endpoint = *results.begin();
   }
+
+  // Create and open acceptor
+  asio::ip::tcp::acceptor acceptor(GetExecutor());
+
+  acceptor.open(endpoint.protocol(), ec);
+  if (ec) {
+    spdlog::error("Error opening acceptor: {}", ec.message());
+    co_return std::unexpected(
+        error::CreateTransportError("Open error: " + ec.message()));
+  }
+
+  acceptor.set_option(asio::ip::tcp::acceptor::reuse_address(true), ec);
+  if (ec) {
+    spdlog::error("Error setting reuse_address: {}", ec.message());
+    co_return std::unexpected(
+        error::CreateTransportError("Set option error: " + ec.message()));
+  }
+
+  acceptor.bind(endpoint, ec);
+  if (ec) {
+    spdlog::error("Error binding acceptor: {}", ec.message());
+    co_return std::unexpected(
+        error::CreateTransportError("Bind error: " + ec.message()));
+  }
+
+  acceptor.listen(asio::socket_base::max_listen_connections, ec);
+  if (ec) {
+    spdlog::error("Error listening: {}", ec.message());
+    co_return std::unexpected(
+        error::CreateTransportError("Listen error: " + ec.message()));
+  }
+
+  spdlog::debug("Listening on {}:{}", address_, port_);
+
+  // Accept a connection
+  co_await acceptor.async_accept(
+      socket_, asio::redirect_error(asio::use_awaitable, ec));
+  if (ec) {
+    spdlog::error("Error accepting connection: {}", ec.message());
+    co_return std::unexpected(
+        error::CreateTransportError("Accept error: " + ec.message()));
+  }
+
+  is_connected_ = true;
+  spdlog::debug("Accepted connection on {}:{}", address_, port_);
+
+  co_return std::expected<void, error::RpcError>{};
 }
 
 }  // namespace jsonrpc::transport

--- a/src/transport/socket_transport.cpp
+++ b/src/transport/socket_transport.cpp
@@ -34,100 +34,127 @@ SocketTransport::~SocketTransport() {
 
 auto SocketTransport::Start()
     -> asio::awaitable<std::expected<void, error::RpcError>> {
-  try {
-    co_await asio::post(GetStrand(), asio::use_awaitable);
+  co_await asio::post(GetStrand(), asio::use_awaitable);
 
-    if (is_started_) {
-      spdlog::debug("SocketTransport already started");
-      co_return std::unexpected(
-          error::CreateTransportError("SocketTransport already started"));
-    }
-
-    if (is_closed_) {
-      spdlog::error("Cannot start a closed transport");
-      co_return std::unexpected(
-          error::CreateTransportError("Cannot start a closed transport"));
-    }
-
-    // Set started flag before performing operations
-    is_started_ = true;
-
-    if (is_server_) {
-      // For server, bind and listen for connections
-      spdlog::info("Starting SocketTransport server at {}:{}", address_, port_);
-      co_await BindAndListen();
-    } else {
-      // For client, fully connect immediately
-      spdlog::info(
-          "Connecting SocketTransport client to {}:{}", address_, port_);
-      co_await Connect();
-      spdlog::debug(
-          "SocketTransport client connected to {}:{}", address_, port_);
-    }
-
-    co_return std::expected<void, error::RpcError>();
-  } catch (const std::exception &e) {
-    spdlog::error("Error in Start(): {}", e.what());
-    is_started_ = false;
-    throw;
+  if (is_started_) {
+    spdlog::debug("SocketTransport already started");
+    co_return std::unexpected(
+        error::CreateTransportError("SocketTransport already started"));
   }
+
+  if (is_closed_) {
+    spdlog::error("Cannot start a closed transport");
+    co_return std::unexpected(
+        error::CreateTransportError("Cannot start a closed transport"));
+  }
+
+  std::expected<void, error::RpcError> result;
+
+  if (is_server_) {
+    spdlog::info("Starting SocketTransport server at {}:{}", address_, port_);
+    result = co_await BindAndListen();
+    if (!result) {
+      spdlog::error(
+          "Error starting SocketTransport server: {}", result.error().message);
+      co_return std::unexpected(result.error());
+    }
+  } else {
+    spdlog::info("Connecting SocketTransport client to {}:{}", address_, port_);
+    result = co_await Connect();
+    if (!result) {
+      spdlog::error(
+          "Error connecting SocketTransport client: {}",
+          result.error().message);
+      co_return std::unexpected(result.error());
+    }
+    spdlog::debug("SocketTransport client connected to {}:{}", address_, port_);
+  }
+
+  is_started_ = true;
+  spdlog::debug("SocketTransport successfully started");
+  co_return std::expected<void, error::RpcError>{};
 }
 
 auto SocketTransport::Close()
     -> asio::awaitable<std::expected<void, error::RpcError>> {
-  try {
-    co_await asio::post(GetStrand(), asio::use_awaitable);
+  co_await asio::post(GetStrand(), asio::use_awaitable);
 
-    if (is_closed_) {
-      spdlog::debug("SocketTransport already closed");
-      co_return std::expected<void, error::RpcError>();
-    }
-
-    is_closed_ = true;
-    is_connected_ = false;
-
-    spdlog::debug("Closing socket transport");
-
-    // Cancel and close the socket safely
-    if (socket_.is_open()) {
-      spdlog::debug("Closing socket");
-      socket_.cancel();
-      asio::error_code ec;
-      socket_.close(ec);
-      if (ec) {
-        spdlog::warn("Error closing socket: {}", ec.message());
-      }
-    }
-
-    // Add an additional synchronization point to ensure all operations posted
-    // to the strand complete
-    co_await asio::post(GetStrand(), asio::use_awaitable);
-
-    co_return std::expected<void, error::RpcError>();
-  } catch (const std::exception &e) {
-    spdlog::error("Error closing socket transport: {}", e.what());
-    throw;
+  if (is_closed_) {
+    spdlog::debug("SocketTransport already closed");
+    co_return std::expected<void, error::RpcError>{};
   }
-}
 
-void SocketTransport::CloseNow() {
-  // Set closed flag to prevent concurrent operations
   is_closed_ = true;
   is_connected_ = false;
 
-  try {
-    // Cancel and close the socket synchronously
-    if (socket_.is_open()) {
-      spdlog::debug("Closing socket synchronously");
-      socket_.cancel();
-      asio::error_code ec;
-      socket_.close(ec);
-      if (ec) {
-        spdlog::warn("Error closing socket: {}", ec.message());
-      }
+  spdlog::debug("Closing socket transport");
+
+  // Cancel and close the socket safely
+  std::error_code ec;
+  if (socket_.is_open()) {
+    socket_.cancel(ec);
+    if (ec) {
+      spdlog::warn("Error canceling socket: {}", ec.message());
     }
+    socket_.close(ec);
+    if (ec) {
+      spdlog::warn("Error closing socket: {}", ec.message());
+    }
+  }
+
+  // Clean up acceptor if this is a server
+  if (is_server_ && acceptor_) {
+    acceptor_->cancel(ec);
+    if (ec) {
+      spdlog::warn("Error canceling acceptor: {}", ec.message());
+    }
+    acceptor_->close(ec);
+    if (ec) {
+      spdlog::warn("Error closing acceptor: {}", ec.message());
+    }
+  }
+
+  spdlog::debug("SocketTransport closed");
+  co_return std::expected<void, error::RpcError>{};
+}
+
+void SocketTransport::CloseNow() {
+  is_closed_ = true;
+  is_connected_ = false;
+
+  auto try_close_socket = [&]() {
+    if (!socket_.is_open()) {
+      return;
+    }
+    spdlog::debug("Closing socket synchronously");
+
+    std::error_code ec;
+    socket_.cancel();
+    socket_.close(ec);
+    if (ec) {
+      spdlog::warn("Error closing socket: {}", ec.message());
+    }
+  };
+
+  auto try_close_acceptor = [&]() {
+    if (!is_server_ || !acceptor_ || !acceptor_->is_open()) {
+      return;
+    }
+    spdlog::debug("Closing acceptor synchronously");
+
+    std::error_code ec;
+    acceptor_->cancel();
+    acceptor_->close(ec);
+    if (ec) {
+      spdlog::warn("Error closing acceptor: {}", ec.message());
+    }
+  };
+
+  try {
+    try_close_socket();
+    try_close_acceptor();
   } catch (const std::exception &e) {
-    spdlog::error("Error in synchronous close: {}", e.what());
+    spdlog::error("Unexpected exception during CloseNow(): {}", e.what());
   }
 }
 
@@ -258,7 +285,9 @@ auto SocketTransport::Connect()
   if (ec) {
     spdlog::error(
         "Error connecting to {}:{}: {}", address_, port_, ec.message());
-    socket_.close();  // cleanup
+    if (socket_.is_open()) {
+      socket_.close();
+    }
     co_return std::unexpected(
         error::CreateTransportError("Connect error: " + ec.message()));
   }
@@ -291,31 +320,34 @@ auto SocketTransport::BindAndListen()
     endpoint = *results.begin();
   }
 
-  // Create and open acceptor
-  asio::ip::tcp::acceptor acceptor(GetExecutor());
+  // Lazily construct the acceptor if not already created
+  if (!acceptor_) {
+    acceptor_ = std::make_unique<asio::ip::tcp::acceptor>(GetExecutor());
+  }
 
-  acceptor.open(endpoint.protocol(), ec);
+  // Create and open acceptor
+  acceptor_->open(endpoint.protocol(), ec);
   if (ec) {
     spdlog::error("Error opening acceptor: {}", ec.message());
     co_return std::unexpected(
         error::CreateTransportError("Open error: " + ec.message()));
   }
 
-  acceptor.set_option(asio::ip::tcp::acceptor::reuse_address(true), ec);
+  acceptor_->set_option(asio::ip::tcp::acceptor::reuse_address(true), ec);
   if (ec) {
     spdlog::error("Error setting reuse_address: {}", ec.message());
     co_return std::unexpected(
         error::CreateTransportError("Set option error: " + ec.message()));
   }
 
-  acceptor.bind(endpoint, ec);
+  acceptor_->bind(endpoint, ec);
   if (ec) {
     spdlog::error("Error binding acceptor: {}", ec.message());
     co_return std::unexpected(
         error::CreateTransportError("Bind error: " + ec.message()));
   }
 
-  acceptor.listen(asio::socket_base::max_listen_connections, ec);
+  acceptor_->listen(asio::socket_base::max_listen_connections, ec);
   if (ec) {
     spdlog::error("Error listening: {}", ec.message());
     co_return std::unexpected(
@@ -325,7 +357,7 @@ auto SocketTransport::BindAndListen()
   spdlog::debug("Listening on {}:{}", address_, port_);
 
   // Accept a connection
-  co_await acceptor.async_accept(
+  co_await acceptor_->async_accept(
       socket_, asio::redirect_error(asio::use_awaitable, ec));
   if (ec) {
     spdlog::error("Error accepting connection: {}", ec.message());

--- a/tests/common/mock_transport.hpp
+++ b/tests/common/mock_transport.hpp
@@ -57,21 +57,25 @@ class MockTransport : public jsonrpc::transport::Transport {
    *
    * @return asio::awaitable<void>
    */
-  auto Start() -> asio::awaitable<void> override {
+  auto Start()
+      -> asio::awaitable<std::expected<void, error::RpcError>> override {
     co_await asio::post(strand_, asio::use_awaitable);
 
     if (is_started_) {
       spdlog::debug("MockTransport already started");
-      co_return;
+      co_return std::unexpected(
+          error::CreateTransportError("MockTransport already started"));
     }
 
     if (is_closed_) {
-      throw std::runtime_error("Cannot start a closed transport");
+      spdlog::error("Cannot start a closed transport");
+      co_return std::unexpected(
+          error::CreateTransportError("Cannot start a closed transport"));
     }
 
     is_started_ = true;
     spdlog::debug("MockTransport started");
-    co_return;
+    co_return std::expected<void, error::RpcError>();
   }
 
   auto SendMessage(std::string message) -> asio::awaitable<void> override {

--- a/tests/common/mock_transport.hpp
+++ b/tests/common/mock_transport.hpp
@@ -33,14 +33,6 @@ class MockTransport : public jsonrpc::transport::Transport {
   auto operator=(const MockTransport&) -> MockTransport& = delete;
   auto operator=(MockTransport&&) -> MockTransport& = delete;
 
-  void CloseNow() override {
-    is_closed_ = true;
-    is_started_ = false;
-    receive_timer_.cancel();
-
-    spdlog::debug("MockTransport closed synchronously");
-  }
-
   auto Start()
       -> asio::awaitable<std::expected<void, error::RpcError>> override {
     co_await asio::post(strand_, asio::use_awaitable);
@@ -60,96 +52,6 @@ class MockTransport : public jsonrpc::transport::Transport {
     is_started_ = true;
     spdlog::debug("MockTransport started");
     co_return std::expected<void, error::RpcError>();
-  }
-
-  auto SendMessage(std::string message)
-      -> asio::awaitable<std::expected<void, error::RpcError>> override {
-    co_await asio::post(strand_, asio::use_awaitable);
-
-    if (is_closed_) {
-      co_return std::unexpected(
-          error::CreateTransportError("Cannot send on closed transport"));
-    }
-
-    if (!is_started_) {
-      co_return std::unexpected(error::CreateTransportError(
-          "Cannot send before transport is started"));
-    }
-
-    sent_requests_.push_back(message);
-    co_return std::expected<void, error::RpcError>();
-  }
-
-  auto ReceiveMessage() -> asio::awaitable<std::string> override {
-    try {
-      // Start with a simple check for closed state
-      if (is_closed_) {
-        spdlog::debug(
-            "MockTransport: ReceiveMessage called after transport was closed");
-        co_return std::string();
-      }
-
-      // Check if transport is started
-      if (!is_started_) {
-        throw std::runtime_error("Cannot receive before transport is started");
-      }
-
-      // Get strand protection
-      co_await asio::post(strand_, asio::use_awaitable);
-
-      // Check again if closed (might have changed while waiting for strand)
-      if (is_closed_) {
-        spdlog::debug("MockTransport: ReceiveMessage found transport closed");
-        co_return std::string();
-      }
-
-      // If we already have messages, return one immediately
-      if (!incoming_messages_.empty()) {
-        auto message = incoming_messages_.front();
-        incoming_messages_.pop();
-        co_return message;
-      }
-
-      // No message available, need to wait
-      // Use a simpler loop with shorter timeouts for more frequent closed
-      // checks
-      while (!is_closed_) {
-        // Set up a short timer so we'll wake up periodically even without
-        // messages
-        receive_timer_.expires_after(std::chrono::milliseconds(10));
-
-        try {
-          // Wait for the timer to expire or be canceled
-          co_await receive_timer_.async_wait(asio::use_awaitable);
-        } catch (const asio::system_error& e) {
-          // Just continue if timer was canceled
-          if (e.code() != asio::error::operation_aborted) {
-            throw;
-          }
-        }
-
-        // Get strand protection to check state
-        co_await asio::post(strand_, asio::use_awaitable);
-
-        // Check if closed while we were waiting
-        if (is_closed_) {
-          co_return std::string();
-        }
-
-        // Check for new messages
-        if (!incoming_messages_.empty()) {
-          auto message = incoming_messages_.front();
-          incoming_messages_.pop();
-          co_return message;
-        }
-      }
-
-      // Transport was closed
-      co_return std::string();
-    } catch (const std::exception& e) {
-      spdlog::error("MockTransport: Error in ReceiveMessage: {}", e.what());
-      throw;
-    }
   }
 
   auto Close()
@@ -183,6 +85,91 @@ class MockTransport : public jsonrpc::transport::Transport {
       spdlog::error("MockTransport: Error in Close: {}", e.what());
       throw;
     }
+  }
+
+  void CloseNow() override {
+    is_closed_ = true;
+    is_started_ = false;
+    receive_timer_.cancel();
+
+    spdlog::debug("MockTransport closed synchronously");
+  }
+
+  auto SendMessage(std::string message)
+      -> asio::awaitable<std::expected<void, error::RpcError>> override {
+    co_await asio::post(strand_, asio::use_awaitable);
+
+    if (is_closed_) {
+      co_return std::unexpected(
+          error::CreateTransportError("Cannot send on closed transport"));
+    }
+
+    if (!is_started_) {
+      co_return std::unexpected(error::CreateTransportError(
+          "Cannot send before transport is started"));
+    }
+
+    sent_requests_.push_back(message);
+    co_return std::expected<void, error::RpcError>();
+  }
+
+  auto ReceiveMessage()
+      -> asio::awaitable<std::expected<std::string, error::RpcError>> override {
+    if (is_closed_) {
+      spdlog::debug(
+          "MockTransport: ReceiveMessage called after transport was closed");
+      co_return std::unexpected(error::CreateTransportError(
+          "ReceiveMessage called after transport was closed"));
+    }
+
+    if (!is_started_) {
+      co_return std::unexpected(error::CreateTransportError(
+          "Cannot receive before transport is started"));
+    }
+
+    co_await asio::post(strand_, asio::use_awaitable);
+
+    if (is_closed_) {
+      spdlog::debug("MockTransport: ReceiveMessage found transport closed");
+      co_return std::unexpected(error::CreateTransportError(
+          "ReceiveMessage called after transport was closed"));
+    }
+
+    if (!incoming_messages_.empty()) {
+      auto message = incoming_messages_.front();
+      incoming_messages_.pop();
+      co_return message;
+    }
+
+    // Poll periodically for new messages
+    while (!is_closed_) {
+      receive_timer_.expires_after(std::chrono::milliseconds(10));
+
+      std::error_code ec;
+      co_await receive_timer_.async_wait(
+          asio::redirect_error(asio::use_awaitable, ec));
+
+      if (ec && ec != asio::error::operation_aborted) {
+        co_return std::unexpected(error::CreateTransportError(
+            "Error during receive wait: " + ec.message()));
+      }
+
+      co_await asio::post(strand_, asio::use_awaitable);
+
+      if (is_closed_) {
+        co_return std::unexpected(error::CreateTransportError(
+            "ReceiveMessage called after transport was closed"));
+      }
+
+      if (!incoming_messages_.empty()) {
+        auto message = incoming_messages_.front();
+        incoming_messages_.pop();
+        co_return message;
+      }
+    }
+
+    co_return std::unexpected(error::CreateTransportError(
+        "ReceiveMessage called after transport was closed"));
   }
 
   auto SetMessage(const std::string& message) -> void {

--- a/tests/common/mock_transport.hpp
+++ b/tests/common/mock_transport.hpp
@@ -56,35 +56,33 @@ class MockTransport : public jsonrpc::transport::Transport {
 
   auto Close()
       -> asio::awaitable<std::expected<void, error::RpcError>> override {
-    try {
-      // Get strand protection
-      co_await asio::post(strand_, asio::use_awaitable);
+    // Get strand protection
+    co_await asio::post(strand_, asio::use_awaitable);
 
-      spdlog::debug("MockTransport: Closing transport");
+    spdlog::debug("MockTransport: Closing transport");
 
-      if (is_closed_) {
-        spdlog::debug("MockTransport: Already closed");
-        co_return std::expected<void, error::RpcError>();
-      }
-
-      // Set the closed flag first
-      is_closed_ = true;
-      is_started_ = false;
-
-      // Cancel timer to interrupt any waiting operations
-      receive_timer_.cancel();
-
-      spdlog::debug("MockTransport: Closed");
-
-      // Add an additional synchronization point to ensure all operations posted
-      // to the strand complete
-      co_await asio::post(strand_, asio::use_awaitable);
-
-      co_return std::expected<void, error::RpcError>();
-    } catch (const std::exception& e) {
-      spdlog::error("MockTransport: Error in Close: {}", e.what());
-      throw;
+    if (is_closed_) {
+      spdlog::debug("MockTransport: Already closed");
+      co_return std::expected<void, error::RpcError>{};
     }
+
+    // Set the closed flag first
+    is_closed_ = true;
+    is_started_ = false;
+
+    asio::error_code ec;
+    receive_timer_.cancel(ec);
+    if (ec) {
+      co_return std::unexpected(error::CreateTransportError(
+          "Failed to cancel receive timer during close", ec));
+    }
+
+    spdlog::debug("MockTransport: Closed");
+
+    // Optional sync point for strand tasks to flush
+    co_await asio::post(strand_, asio::use_awaitable);
+
+    co_return std::expected<void, error::RpcError>{};
   }
 
   void CloseNow() override {

--- a/tests/common/mock_transport.hpp
+++ b/tests/common/mock_transport.hpp
@@ -21,28 +21,19 @@ class MockTransport : public jsonrpc::transport::Transport {
       : Transport(executor),
         strand_(asio::make_strand(executor)),
         receive_timer_(executor) {
-    spdlog::debug("Created mock transport");
   }
 
   ~MockTransport() override {
-    // Ensure we're closed when destroyed - use the synchronous method
     spdlog::debug("Destroying mock transport");
     CloseNow();
   }
 
-  // Delete copy/move operations to follow Rule of Five
   MockTransport(const MockTransport&) = delete;
   MockTransport(MockTransport&&) = delete;
   auto operator=(const MockTransport&) -> MockTransport& = delete;
   auto operator=(MockTransport&&) -> MockTransport& = delete;
 
-  /**
-   * @brief Close the transport synchronously
-   *
-   * This is safe to use in destructors
-   */
   void CloseNow() override {
-    // Set closed flag and cancel any timers
     is_closed_ = true;
     is_started_ = false;
     receive_timer_.cancel();
@@ -50,13 +41,6 @@ class MockTransport : public jsonrpc::transport::Transport {
     spdlog::debug("MockTransport closed synchronously");
   }
 
-  /**
-   * @brief Start the transport
-   *
-   * For MockTransport, this just sets the is_started_ flag.
-   *
-   * @return asio::awaitable<void>
-   */
   auto Start()
       -> asio::awaitable<std::expected<void, error::RpcError>> override {
     co_await asio::post(strand_, asio::use_awaitable);
@@ -78,19 +62,22 @@ class MockTransport : public jsonrpc::transport::Transport {
     co_return std::expected<void, error::RpcError>();
   }
 
-  auto SendMessage(std::string message) -> asio::awaitable<void> override {
+  auto SendMessage(std::string message)
+      -> asio::awaitable<std::expected<void, error::RpcError>> override {
     co_await asio::post(strand_, asio::use_awaitable);
 
     if (is_closed_) {
-      throw std::runtime_error("Cannot send on closed transport");
+      co_return std::unexpected(
+          error::CreateTransportError("Cannot send on closed transport"));
     }
 
     if (!is_started_) {
-      throw std::runtime_error("Cannot send before transport is started");
+      co_return std::unexpected(error::CreateTransportError(
+          "Cannot send before transport is started"));
     }
 
     sent_requests_.push_back(message);
-    co_return;
+    co_return std::expected<void, error::RpcError>();
   }
 
   auto ReceiveMessage() -> asio::awaitable<std::string> override {

--- a/tests/common/mock_transport.hpp
+++ b/tests/common/mock_transport.hpp
@@ -165,7 +165,8 @@ class MockTransport : public jsonrpc::transport::Transport {
     }
   }
 
-  auto Close() -> asio::awaitable<void> override {
+  auto Close()
+      -> asio::awaitable<std::expected<void, error::RpcError>> override {
     try {
       // Get strand protection
       co_await asio::post(strand_, asio::use_awaitable);
@@ -174,7 +175,7 @@ class MockTransport : public jsonrpc::transport::Transport {
 
       if (is_closed_) {
         spdlog::debug("MockTransport: Already closed");
-        co_return;  // Already closed
+        co_return std::expected<void, error::RpcError>();
       }
 
       // Set the closed flag first
@@ -190,7 +191,7 @@ class MockTransport : public jsonrpc::transport::Transport {
       // to the strand complete
       co_await asio::post(strand_, asio::use_awaitable);
 
-      co_return;
+      co_return std::expected<void, error::RpcError>();
     } catch (const std::exception& e) {
       spdlog::error("MockTransport: Error in Close: {}", e.what());
       throw;

--- a/tests/endpoint/dispatcher_test.cpp
+++ b/tests/endpoint/dispatcher_test.cpp
@@ -6,10 +6,8 @@
 #include <nlohmann/json.hpp>
 #include <spdlog/spdlog.h>
 
-#include "jsonrpc/endpoint/types.hpp"
-
 using jsonrpc::endpoint::Dispatcher;
-using jsonrpc::endpoint::ErrorCode;
+using jsonrpc::error::ErrorCode;
 
 // Helper function for running dispatcher tests
 template <typename TestFunc>

--- a/tests/endpoint/dispatcher_test.cpp
+++ b/tests/endpoint/dispatcher_test.cpp
@@ -56,7 +56,7 @@ TEST_CASE("Method registration and handling", "[Dispatcher]") {
     auto response = co_await dispatcher.DispatchRequest(
         R"({"jsonrpc":"2.0","method":"sum","params":[1,2,3],"id":1})");
     REQUIRE(response.has_value());
-    auto result = nlohmann::json::parse(*response);
+    auto result = nlohmann::json::parse(response.value());
     REQUIRE(result["result"] == 6);
     co_return;
   });
@@ -88,7 +88,7 @@ TEST_CASE("Batch request handling", "[Dispatcher]") {
       ])";
       auto response = co_await dispatcher.DispatchRequest(batch_request);
       REQUIRE(response.has_value());
-      auto result = nlohmann::json::parse(*response);
+      auto result = nlohmann::json::parse(response.value());
       REQUIRE(result.is_array());
       REQUIRE(result.size() == 2);
       REQUIRE(result[0]["result"] == 3);

--- a/tests/endpoint/endpoint_test.cpp
+++ b/tests/endpoint/endpoint_test.cpp
@@ -55,7 +55,8 @@ TEST_CASE("RpcEndpoint - Basic lifecycle", "[endpoint]") {
           std::make_unique<RpcEndpoint>(executor, std::move(transport));
 
       // Start and shutdown
-      co_await endpoint->Start();
+      auto start_result = co_await endpoint->Start();
+      REQUIRE(start_result);
       co_await endpoint->Shutdown();
     });
   }
@@ -68,10 +69,14 @@ TEST_CASE("RpcEndpoint - Basic lifecycle", "[endpoint]") {
           std::make_unique<RpcEndpoint>(executor, std::move(transport));
 
       // First start should succeed
-      co_await endpoint->Start();
+      auto start_result = co_await endpoint->Start();
+      REQUIRE(start_result);
 
       // Second start should throw
-      REQUIRE_THROWS_AS(co_await endpoint->Start(), std::runtime_error);
+      auto start_result2 = co_await endpoint->Start();
+      REQUIRE_FALSE(start_result2);
+      REQUIRE(
+          start_result2.error().message == "RPC endpoint is already running");
 
       // Shutdown should work
       co_await endpoint->Shutdown();
@@ -82,74 +87,3 @@ TEST_CASE("RpcEndpoint - Basic lifecycle", "[endpoint]") {
     });
   }
 }
-
-// // Basic Request/Response Format Tests
-// TEST_CASE("RpcEndpoint - Message format", "[endpoint]") {
-//   asio::io_context io_ctx;
-
-//   SECTION("Notification format") {
-//     RunTest([&]() -> asio::awaitable<void> {
-//       auto transport = std::make_unique<MockTransport>(io_ctx);
-//       auto* transport_ptr = transport.get();
-//       auto endpoint = std::make_unique<RpcEndpoint>(std::move(transport));
-
-//       co_await endpoint->Start();
-
-//       // Send a notification
-//       Json params = {{"event", "update"}, {"value", 100}};
-//       co_await endpoint->SendNotification("test_notification", params);
-
-//       // Verify notification format
-//       REQUIRE(!transport_ptr->GetSentRequests().empty());
-//       auto sent_notification =
-//           Json::parse(transport_ptr->GetSentRequests().back());
-//       REQUIRE(sent_notification["jsonrpc"] == "2.0");
-//       REQUIRE(sent_notification["method"] == "test_notification");
-//       REQUIRE(sent_notification["params"] == params);
-//       REQUIRE_FALSE(sent_notification.contains("id"));
-
-//       co_await endpoint->Shutdown();
-//     });
-//   }
-// }
-
-// // Method Registration Tests
-// TEST_CASE("RpcEndpoint - Method registration", "[endpoint]") {
-//   asio::io_context io_ctx;
-
-//   SECTION("Method registration") {
-//     RunTest([&]() -> asio::awaitable<void> {
-//       auto transport = std::make_unique<MockTransport>(io_ctx);
-//       auto endpoint = std::make_unique<RpcEndpoint>(std::move(transport));
-
-//       co_await endpoint->Start();
-
-//       // Register a method
-//       endpoint->RegisterMethodCall(
-//           "test_method",
-//           [](const std::optional<nlohmann::json>& params)
-//               -> asio::awaitable<nlohmann::json> {
-//             co_return nlohmann::json::object({{"result", "success"}});
-//           });
-
-//       co_await endpoint->Shutdown();
-//     });
-//   }
-
-//   SECTION("Notification registration") {
-//     RunTest([&]() -> asio::awaitable<void> {
-//       auto transport = std::make_unique<MockTransport>(io_ctx);
-//       auto endpoint = std::make_unique<RpcEndpoint>(std::move(transport));
-
-//       co_await endpoint->Start();
-
-//       // Register a notification handler
-//       endpoint->RegisterNotification(
-//           "test_notification",
-//           [](const std::optional<nlohmann::json>& params)
-//               -> asio::awaitable<void> { co_return; });
-
-//       co_await endpoint->Shutdown();
-//     });
-//   }
-// }

--- a/tests/endpoint/endpoint_test.cpp
+++ b/tests/endpoint/endpoint_test.cpp
@@ -57,7 +57,8 @@ TEST_CASE("RpcEndpoint - Basic lifecycle", "[endpoint]") {
       // Start and shutdown
       auto start_result = co_await endpoint->Start();
       REQUIRE(start_result);
-      co_await endpoint->Shutdown();
+      auto shutdown_result = co_await endpoint->Shutdown();
+      REQUIRE(shutdown_result);
     });
   }
 
@@ -79,7 +80,8 @@ TEST_CASE("RpcEndpoint - Basic lifecycle", "[endpoint]") {
           start_result2.error().message == "RPC endpoint is already running");
 
       // Shutdown should work
-      co_await endpoint->Shutdown();
+      auto shutdown_result = co_await endpoint->Shutdown();
+      REQUIRE(shutdown_result);
 
       // Verify endpoint is no longer running
       bool is_running = endpoint->IsRunning();

--- a/tests/endpoint/response_test.cpp
+++ b/tests/endpoint/response_test.cpp
@@ -14,7 +14,7 @@ TEST_CASE("Response creation and basic properties", "[Response]") {
   SECTION("Create success response with result") {
     nlohmann::json result = {{"data", "test_value"}};
     RequestId id = 1;
-    auto response = Response::CreateResult(result, id);
+    auto response = Response::CreateSuccess(result, id);
 
     REQUIRE(response.IsSuccess());
     REQUIRE(response.GetResult() == result);
@@ -23,7 +23,7 @@ TEST_CASE("Response creation and basic properties", "[Response]") {
 
   SECTION("Create error response") {
     RequestId id = "req1";
-    auto response = Response::CreateLibError(ErrorCode::kMethodNotFound, id);
+    auto response = Response::CreateError(ErrorCode::kMethodNotFound, id);
 
     REQUIRE_FALSE(response.IsSuccess());
     REQUIRE(
@@ -34,7 +34,7 @@ TEST_CASE("Response creation and basic properties", "[Response]") {
 
   SECTION("Create response without id") {
     nlohmann::json result = "test";
-    auto response = Response::CreateResult(result, std::nullopt);
+    auto response = Response::CreateSuccess(result, std::nullopt);
 
     REQUIRE(response.IsSuccess());
     REQUIRE(response.GetResult() == result);
@@ -43,7 +43,7 @@ TEST_CASE("Response creation and basic properties", "[Response]") {
 
   SECTION("Create success response") {
     nlohmann::json result = {{"key", "value"}};
-    auto response = Response::CreateResult(result, std::nullopt);
+    auto response = Response::CreateSuccess(result, std::nullopt);
 
     REQUIRE(response.IsSuccess());
     REQUIRE(response.GetResult() == result);
@@ -53,7 +53,7 @@ TEST_CASE("Response creation and basic properties", "[Response]") {
   SECTION("Create success response with ID") {
     nlohmann::json result = {{"key", "value"}};
     RequestId id = "req1";
-    auto response = Response::CreateResult(result, id);
+    auto response = Response::CreateSuccess(result, id);
 
     REQUIRE(response.IsSuccess());
     REQUIRE(response.GetResult() == result);
@@ -63,7 +63,7 @@ TEST_CASE("Response creation and basic properties", "[Response]") {
   }
 
   SECTION("Create error response") {
-    auto response = Response::CreateLibError(ErrorCode::kMethodNotFound);
+    auto response = Response::CreateError(ErrorCode::kMethodNotFound);
 
     REQUIRE_FALSE(response.IsSuccess());
     REQUIRE(response.GetError()["code"] == -32601);
@@ -76,7 +76,7 @@ TEST_CASE("Response JSON serialization", "[Response]") {
   SECTION("Serialize success response") {
     nlohmann::json result = {{"key", "value"}};
     RequestId id = 1;
-    auto response = Response::CreateResult(result, id);
+    auto response = Response::CreateSuccess(result, id);
     auto json = response.ToJson();
 
     REQUIRE(json["jsonrpc"] == "2.0");
@@ -87,7 +87,7 @@ TEST_CASE("Response JSON serialization", "[Response]") {
 
   SECTION("Serialize error response") {
     RequestId id = "req1";
-    auto response = Response::CreateLibError(ErrorCode::kInvalidRequest, id);
+    auto response = Response::CreateError(ErrorCode::kInvalidRequest, id);
     auto json = response.ToJson();
 
     REQUIRE(json["jsonrpc"] == "2.0");
@@ -98,7 +98,7 @@ TEST_CASE("Response JSON serialization", "[Response]") {
   }
 
   SECTION("Serialize response without id") {
-    auto response = Response::CreateLibError(ErrorCode::kParseError);
+    auto response = Response::CreateError(ErrorCode::kParseError);
     auto json = response.ToJson();
 
     REQUIRE(json["jsonrpc"] == "2.0");

--- a/tests/endpoint/response_test.cpp
+++ b/tests/endpoint/response_test.cpp
@@ -4,10 +4,12 @@
 #include <nlohmann/json.hpp>
 
 #include "jsonrpc/endpoint/types.hpp"
+#include "jsonrpc/error/error.hpp"
 
-using jsonrpc::endpoint::ErrorCode;
 using jsonrpc::endpoint::RequestId;
 using jsonrpc::endpoint::Response;
+using jsonrpc::error::ErrorCode;
+using jsonrpc::error::RpcError;
 
 TEST_CASE("Response creation and basic properties", "[Response]") {
   SECTION("Create success response with result") {
@@ -112,9 +114,10 @@ TEST_CASE("Response deserialization", "[Response]") {
         {"jsonrpc", "2.0"}, {"result", {{"key", "value"}}}, {"id", 1}};
 
     auto response = Response::FromJson(json);
-    REQUIRE(response.IsSuccess());
-    REQUIRE(response.GetResult()["key"] == "value");
-    auto id = response.GetId();
+    REQUIRE(response.has_value());
+    REQUIRE(response->IsSuccess());
+    REQUIRE(response->GetResult()["key"] == "value");
+    auto id = response->GetId();
     REQUIRE(id.has_value());
     REQUIRE(std::get<int64_t>(*id) == 1);
   }
@@ -126,10 +129,11 @@ TEST_CASE("Response deserialization", "[Response]") {
         {"id", "req1"}};
 
     auto response = Response::FromJson(json);
-    REQUIRE_FALSE(response.IsSuccess());
-    REQUIRE(response.GetError()["code"] == -32601);
-    REQUIRE(response.GetError()["message"] == "Method not found");
-    auto id = response.GetId();
+    REQUIRE(response.has_value());
+    REQUIRE_FALSE(response->IsSuccess());
+    REQUIRE(response->GetError()["code"] == -32601);
+    REQUIRE(response->GetError()["message"] == "Method not found");
+    auto id = response->GetId();
     REQUIRE(id.has_value());
     REQUIRE(std::get<std::string>(*id) == "req1");
   }
@@ -138,12 +142,16 @@ TEST_CASE("Response deserialization", "[Response]") {
 TEST_CASE("Response validation", "[Response]") {
   SECTION("Invalid JSON-RPC version") {
     nlohmann::json json = {{"jsonrpc", "1.0"}, {"result", "test"}, {"id", 1}};
-    REQUIRE_THROWS_AS(Response::FromJson(json), std::invalid_argument);
+    auto response = Response::FromJson(json);
+    REQUIRE_FALSE(response.has_value());
+    REQUIRE(response.error().code == ErrorCode::kInvalidRequest);
   }
 
   SECTION("Missing both result and error") {
     nlohmann::json json = {{"jsonrpc", "2.0"}, {"id", 1}};
-    REQUIRE_THROWS_AS(Response::FromJson(json), std::invalid_argument);
+    auto response = Response::FromJson(json);
+    REQUIRE_FALSE(response.has_value());
+    REQUIRE(response.error().code == ErrorCode::kInvalidRequest);
   }
 
   SECTION("Both result and error present") {
@@ -152,7 +160,9 @@ TEST_CASE("Response validation", "[Response]") {
         {"result", "test"},
         {"error", {{"code", -32601}, {"message", "Method not found"}}},
         {"id", 1}};
-    REQUIRE_THROWS_AS(Response::FromJson(json), std::invalid_argument);
+    auto response = Response::FromJson(json);
+    REQUIRE_FALSE(response.has_value());
+    REQUIRE(response.error().code == ErrorCode::kInvalidRequest);
   }
 
   SECTION("Invalid error object") {
@@ -160,6 +170,8 @@ TEST_CASE("Response validation", "[Response]") {
         {"jsonrpc", "2.0"},
         {"error", {{"message", "Method not found"}}},  // Missing code
         {"id", 1}};
-    REQUIRE_THROWS_AS(Response::FromJson(json), std::invalid_argument);
+    auto response = Response::FromJson(json);
+    REQUIRE_FALSE(response.has_value());
+    REQUIRE(response.error().code == ErrorCode::kInvalidRequest);
   }
 }

--- a/tests/endpoint/response_test.cpp
+++ b/tests/endpoint/response_test.cpp
@@ -9,7 +9,6 @@
 using jsonrpc::endpoint::RequestId;
 using jsonrpc::endpoint::Response;
 using jsonrpc::error::ErrorCode;
-using jsonrpc::error::RpcError;
 
 TEST_CASE("Response creation and basic properties", "[Response]") {
   SECTION("Create success response with result") {

--- a/tests/transports/framed_pipe_transport_test.cpp
+++ b/tests/transports/framed_pipe_transport_test.cpp
@@ -92,10 +92,12 @@ TEST_CASE("FramedPipeTransport basic communication", "[FramedPipeTransport]") {
         asio::detached);
 
     // Receiver gets complete messages regardless of how they were sent
-    std::string received1 = co_await framed_receiver->ReceiveMessage();
-    REQUIRE(received1 == msg1);
-    std::string received2 = co_await framed_receiver->ReceiveMessage();
-    REQUIRE(received2 == msg2);
+    auto received1 = co_await framed_receiver->ReceiveMessage();
+    REQUIRE(received1.has_value());
+    REQUIRE(received1.value() == msg1);
+    auto received2 = co_await framed_receiver->ReceiveMessage();
+    REQUIRE(received2.has_value());
+    REQUIRE(received2.value() == msg2);
 
     co_await raw_sender->Close();
     co_await framed_receiver->Close();
@@ -144,8 +146,9 @@ TEST_CASE(
           },
           asio::detached);
 
-      std::string received = co_await framed_receiver->ReceiveMessage();
-      REQUIRE(received == message);
+      auto received = co_await framed_receiver->ReceiveMessage();
+      REQUIRE(received.has_value());
+      REQUIRE(received.value() == message);
     }
 
     SECTION("Split in middle of length value") {
@@ -171,8 +174,9 @@ TEST_CASE(
           },
           asio::detached);
 
-      std::string received = co_await framed_receiver->ReceiveMessage();
-      REQUIRE(received == message);
+      auto received = co_await framed_receiver->ReceiveMessage();
+      REQUIRE(received.has_value());
+      REQUIRE(received.value() == message);
     }
 
     SECTION("Split at header boundary") {
@@ -195,8 +199,9 @@ TEST_CASE(
           },
           asio::detached);
 
-      std::string received = co_await framed_receiver->ReceiveMessage();
-      REQUIRE(received == message);
+      auto received = co_await framed_receiver->ReceiveMessage();
+      REQUIRE(received.has_value());
+      REQUIRE(received.value() == message);
     }
 
     SECTION("Split in middle of delimiter") {
@@ -221,8 +226,9 @@ TEST_CASE(
           },
           asio::detached);
 
-      std::string received = co_await framed_receiver->ReceiveMessage();
-      REQUIRE(received == message);
+      auto received = co_await framed_receiver->ReceiveMessage();
+      REQUIRE(received.has_value());
+      REQUIRE(received.value() == message);
     }
 
     SECTION("Split into tiny chunks") {
@@ -239,8 +245,9 @@ TEST_CASE(
           },
           asio::detached);
 
-      std::string received = co_await framed_receiver->ReceiveMessage();
-      REQUIRE(received == message);
+      auto received = co_await framed_receiver->ReceiveMessage();
+      REQUIRE(received.has_value());
+      REQUIRE(received.value() == message);
     }
 
     co_await raw_sender->Close();
@@ -291,8 +298,9 @@ TEST_CASE(
 
     // Receive all messages
     for (const auto& expected : messages) {
-      std::string received = co_await framed_receiver->ReceiveMessage();
-      REQUIRE(received == expected);
+      auto received = co_await framed_receiver->ReceiveMessage();
+      REQUIRE(received.has_value());
+      REQUIRE(received.value() == expected);
     }
 
     co_await raw_sender->Close();
@@ -352,11 +360,13 @@ TEST_CASE(
           asio::detached);
 
       // Receive both messages
-      std::string received1 = co_await framed_receiver->ReceiveMessage();
-      REQUIRE(received1 == msg1);
+      auto received1 = co_await framed_receiver->ReceiveMessage();
+      REQUIRE(received1.has_value());
+      REQUIRE(received1.value() == msg1);
 
-      std::string received2 = co_await framed_receiver->ReceiveMessage();
-      REQUIRE(received2 == msg2);
+      auto received2 = co_await framed_receiver->ReceiveMessage();
+      REQUIRE(received2.has_value());
+      REQUIRE(received2.value() == msg2);
     }
 
     SECTION("Overlapping messages with proper header-content order") {
@@ -393,11 +403,13 @@ TEST_CASE(
           asio::detached);
 
       // Receive both messages
-      std::string received1 = co_await framed_receiver->ReceiveMessage();
-      REQUIRE(received1 == msg1);
+      auto received1 = co_await framed_receiver->ReceiveMessage();
+      REQUIRE(received1.has_value());
+      REQUIRE(received1.value() == msg1);
 
-      std::string received2 = co_await framed_receiver->ReceiveMessage();
-      REQUIRE(received2 == msg2);
+      auto received2 = co_await framed_receiver->ReceiveMessage();
+      REQUIRE(received2.has_value());
+      REQUIRE(received2.value() == msg2);
     }
 
     co_await raw_sender->Close();
@@ -443,7 +455,11 @@ TEST_CASE(
         asio::detached);
 
     // Should throw or return error when trying to parse invalid length
-    REQUIRE_THROWS(co_await framed_receiver->ReceiveMessage());
+    auto result = co_await framed_receiver->ReceiveMessage();
+    REQUIRE(!result.has_value());
+    REQUIRE(
+        result.error().message.find("Invalid Content-Length header") !=
+        std::string::npos);
 
     co_await raw_sender->Close();
     co_await framed_receiver->Close();
@@ -487,7 +503,11 @@ TEST_CASE(
         asio::detached);
 
     // Should throw or return error when trying to parse message without header
-    REQUIRE_THROWS(co_await framed_receiver->ReceiveMessage());
+    auto result = co_await framed_receiver->ReceiveMessage();
+    REQUIRE(!result.has_value());
+    REQUIRE(
+        result.error().message.find("Missing Content-Length header") !=
+        std::string::npos);
 
     co_await raw_sender->Close();
     co_await framed_receiver->Close();

--- a/tests/transports/pipe_transport_test.cpp
+++ b/tests/transports/pipe_transport_test.cpp
@@ -81,48 +81,44 @@ TEST_CASE(
     "PipeTransport starts server and client communication", "[PipeTransport]") {
   RunTest([](asio::any_io_executor executor) -> asio::awaitable<void> {
     std::string socket_path = "/tmp/test_socket";
-
-    // Create a server transport
     auto strand = asio::make_strand(executor);
-    jsonrpc::transport::PipeTransport server_transport(
-        executor, socket_path, true);
 
-    // Start server message handling in a separate coroutine
+    // Start server thread
     asio::co_spawn(
         strand,
-        [&server_transport]() -> asio::awaitable<void> {
-          spdlog::info("Server is waiting for a client...");
-          co_await server_transport.Start();
-          spdlog::info("Server accepted a client!");
+        [executor, socket_path]() -> asio::awaitable<void> {
+          jsonrpc::transport::PipeTransport server_transport(
+              executor, socket_path, true);
+          auto start_result = co_await server_transport.Start();
+          REQUIRE(start_result);
 
-          // Now it's safe to receive the message
           auto received_message = co_await server_transport.ReceiveMessage();
           REQUIRE(received_message == "Hello, Server!");
+
+          auto close_result = co_await server_transport.Close();
+          REQUIRE(close_result);
         },
         asio::detached);
 
-    // Start the client and connect to the server
-    jsonrpc::transport::PipeTransport client_transport(
-        executor, socket_path, false);
-
-    // Make sure `SendMessage()` runs in a separate coroutine
+    // Start the client thread
     asio::co_spawn(
         strand,
-        [&client_transport]() -> asio::awaitable<void> {
+        [executor, socket_path]() -> asio::awaitable<void> {
+          jsonrpc::transport::PipeTransport client_transport(
+              executor, socket_path, false);
+          auto start_result = co_await client_transport.Start();
+          REQUIRE(start_result);
+
           co_await client_transport.SendMessage("Hello, Server!");
+
+          auto close_result = co_await client_transport.Close();
+          REQUIRE(close_result);
         },
         asio::detached);
 
-    // Close the server *within the strand* to ensure ordering
-    asio::co_spawn(
-        strand,
-        [&server_transport]() -> asio::awaitable<void> {
-          co_await server_transport.Close();
-        },
-        asio::detached);
-
-    // Close the client transport
-    co_await client_transport.Close();
+    // Wait for both threads to complete
+    co_await asio::steady_timer(executor, std::chrono::seconds(1))
+        .async_wait(asio::use_awaitable);
   });
 }
 
@@ -141,51 +137,48 @@ TEST_CASE("PipeTransport throws on invalid socket path", "[PipeTransport]") {
 TEST_CASE("PipeTransport handles multiple messages", "[PipeTransport]") {
   RunTest([](asio::any_io_executor executor) -> asio::awaitable<void> {
     std::string socket_path = "/tmp/test_socket_multi";
-
-    // Create a server transport
     auto strand = asio::make_strand(executor);
-    jsonrpc::transport::PipeTransport server_transport(
-        executor, socket_path, true);
 
-    // Start server message handling in a separate coroutine
+    // Start server thread
     asio::co_spawn(
         strand,
-        [&server_transport]() -> asio::awaitable<void> {
-          spdlog::info("Server is waiting for a client...");
-          co_await server_transport.Start();
+        [executor, socket_path]() -> asio::awaitable<void> {
+          jsonrpc::transport::PipeTransport server_transport(
+              executor, socket_path, true);
+          auto start_result = co_await server_transport.Start();
+          REQUIRE(start_result);
 
-          // Now it's safe to receive the message
           for (int i = 0; i < 10; ++i) {
             auto received_message = co_await server_transport.ReceiveMessage();
             REQUIRE(received_message == "Hello, Server! " + std::to_string(i));
           }
+
+          auto close_result = co_await server_transport.Close();
+          REQUIRE(close_result);
         },
         asio::detached);
 
-    // Start the client and connect to the server
-    jsonrpc::transport::PipeTransport client_transport(
-        executor, socket_path, false);
-
-    // Make sure `SendMessage()` runs in a separate coroutine
+    // Start the client thread
     asio::co_spawn(
         strand,
-        [&client_transport]() -> asio::awaitable<void> {
+        [executor, socket_path]() -> asio::awaitable<void> {
+          jsonrpc::transport::PipeTransport client_transport(
+              executor, socket_path, false);
+          auto start_result = co_await client_transport.Start();
+          REQUIRE(start_result);
+
           for (int i = 0; i < 10; ++i) {
             co_await client_transport.SendMessage(
                 "Hello, Server! " + std::to_string(i));
           }
+
+          auto close_result = co_await client_transport.Close();
+          REQUIRE(close_result);
         },
         asio::detached);
 
-    // Close the server *within the strand* to ensure ordering
-    asio::co_spawn(
-        strand,
-        [&server_transport]() -> asio::awaitable<void> {
-          co_await server_transport.Close();
-        },
-        asio::detached);
-
-    // Close the client transport
-    co_await client_transport.Close();
+    // Wait for both threads to complete
+    co_await asio::steady_timer(executor, std::chrono::seconds(1))
+        .async_wait(asio::use_awaitable);
   });
 }

--- a/tests/transports/pipe_transport_test.cpp
+++ b/tests/transports/pipe_transport_test.cpp
@@ -92,8 +92,7 @@ TEST_CASE(
         strand,
         [&server_transport]() -> asio::awaitable<void> {
           spdlog::info("Server is waiting for a client...");
-          co_await server_transport.GetSocket().async_wait(
-              asio::socket_base::wait_read, asio::use_awaitable);
+          co_await server_transport.Start();
           spdlog::info("Server accepted a client!");
 
           // Now it's safe to receive the message
@@ -153,9 +152,7 @@ TEST_CASE("PipeTransport handles multiple messages", "[PipeTransport]") {
         strand,
         [&server_transport]() -> asio::awaitable<void> {
           spdlog::info("Server is waiting for a client...");
-          co_await server_transport.GetSocket().async_wait(
-              asio::socket_base::wait_read, asio::use_awaitable);
-          spdlog::info("Server accepted a client!");
+          co_await server_transport.Start();
 
           // Now it's safe to receive the message
           for (int i = 0; i < 10; ++i) {


### PR DESCRIPTION
## Summary

- Updated build system to require C++23.
- Replaced exception-based error handling with `std::expected`.
- Overhauled error-handling logic across most classes.
- Improves robustness and clarity of error reporting.
