### PR TITLE
Fix infinite recursion in typed RPC functions and improve logging

### DIFF
--- a/examples/lsp_example/server/lsp_server.cpp
+++ b/examples/lsp_example/server/lsp_server.cpp
@@ -40,7 +40,7 @@ auto HandleShutdown(std::weak_ptr<RpcEndpoint> weak) -> asio::awaitable<void> {
 void RegisterLSPHandlers(std::shared_ptr<RpcEndpoint> server) {
   server->RegisterMethodCall(
       "initialize", [](std::optional<Json> params) -> asio::awaitable<Json> {
-        spdlog::info("LSP Server initialized");
+        spdlog::debug("LspExample server initialized");
         Json response = {
             {"capabilities",
              {{"positionEncoding", "utf-16"},
@@ -57,7 +57,7 @@ void RegisterLSPHandlers(std::shared_ptr<RpcEndpoint> server) {
 
   server->RegisterNotification(
       "initialized", [](std::optional<Json> params) -> asio::awaitable<void> {
-        spdlog::info("Client initialized");
+        spdlog::debug("LspExample client initialized");
         co_return;
       });
 
@@ -77,7 +77,7 @@ void RegisterLSPHandlers(std::shared_ptr<RpcEndpoint> server) {
 
   server->RegisterMethodCall(
       "shutdown", [](std::optional<Json> params) -> asio::awaitable<Json> {
-        spdlog::info("Server shutting down");
+        spdlog::debug("LspExample server shutting down");
         co_return Json::object();
       });
 
@@ -104,7 +104,7 @@ auto RunLSPServer(asio::any_io_executor executor, std::string pipe_name)
   // Step 5: Wait for server shutdown
   co_await server->WaitForShutdown();
 
-  spdlog::info("Server shutdown monitoring complete");
+  spdlog::debug("LspExample server shutdown monitoring complete");
   co_return;
 }
 
@@ -115,14 +115,15 @@ auto HandleError(std::exception_ptr eptr) -> void {
       std::rethrow_exception(eptr);
     }
   } catch (const std::exception& e) {
-    spdlog::error("Server error: {}", e.what());
+    spdlog::error("LspExample server error: {}", e.what());
   }
 }
 
 auto main(int argc, char* argv[]) -> int {
   // Step 1: Setup logging
   auto cout_sink = std::make_shared<spdlog::sinks::ostream_sink_mt>(std::cout);
-  auto logger = std::make_shared<spdlog::logger>("server_logger", cout_sink);
+  auto logger = std::make_shared<spdlog::logger>("server", cout_sink);
+  logger->set_pattern("[%n] [%l] %v");
   spdlog::set_default_logger(logger);
   spdlog::set_level(spdlog::level::debug);
   spdlog::flush_on(spdlog::level::debug);
@@ -130,7 +131,7 @@ auto main(int argc, char* argv[]) -> int {
   // Step 2: Parse command line arguments
   const std::vector<std::string> args(argv, argv + argc);
   const std::string pipe_name = ParsePipeArguments(args);
-  spdlog::info("Starting LSP server on pipe: {}", pipe_name);
+  spdlog::debug("LspExample starting server on pipe: {}", pipe_name);
 
   // Step 3: Create an io_context for asio operations
   asio::io_context io_context;
@@ -142,6 +143,6 @@ auto main(int argc, char* argv[]) -> int {
   // Step 5: Run the io_context
   io_context.run();
 
-  spdlog::info("Server shutdown complete");
+  spdlog::debug("LspExample server shutdown complete");
   return 0;
 }

--- a/include/jsonrpc/endpoint/endpoint.hpp
+++ b/include/jsonrpc/endpoint/endpoint.hpp
@@ -57,7 +57,11 @@ class RpcEndpoint {
 
   template <typename ParamsType, typename ResultType>
   auto SendMethodCall(std::string method, ParamsType params)
-      -> asio::awaitable<std::expected<ResultType, RpcError>>;
+      -> asio::awaitable<std::expected<ResultType, RpcError>>
+    requires(
+        !std::is_same_v<std::decay_t<ParamsType>, nlohmann::json> &&
+        !std::is_same_v<
+            std::decay_t<ParamsType>, std::optional<nlohmann::json>>);
 
   auto SendNotification(
       std::string method, std::optional<nlohmann::json> params = std::nullopt)
@@ -65,7 +69,11 @@ class RpcEndpoint {
 
   template <typename ParamsType>
   auto SendNotification(std::string method, ParamsType params)
-      -> asio::awaitable<std::expected<void, RpcError>>;
+      -> asio::awaitable<std::expected<void, RpcError>>
+    requires(
+        !std::is_same_v<std::decay_t<ParamsType>, nlohmann::json> &&
+        !std::is_same_v<
+            std::decay_t<ParamsType>, std::optional<nlohmann::json>>);
 
   void RegisterMethodCall(
       std::string method, typename Dispatcher::MethodCallHandler handler);
@@ -125,23 +133,32 @@ class RpcEndpoint {
 
 template <typename ParamsType, typename ResultType>
 auto RpcEndpoint::SendMethodCall(std::string method, ParamsType params)
-    -> asio::awaitable<std::expected<ResultType, RpcError>> {
+    -> asio::awaitable<std::expected<ResultType, RpcError>>
+  requires(
+      !std::is_same_v<std::decay_t<ParamsType>, nlohmann::json> &&
+      !std::is_same_v<std::decay_t<ParamsType>, std::optional<nlohmann::json>>)
+{
+  spdlog::debug("RpcEndpoint sending typed method call: {}", method);
   nlohmann::json json_params;
   try {
     json_params = params;
   } catch (const nlohmann::json::exception &ex) {
+    spdlog::error(
+        "RpcEndpoint failed to convert parameters to JSON: {}", ex.what());
     co_return error::CreateClientError(
         "Failed to convert parameters to JSON: " + std::string(ex.what()));
   }
 
-  auto result = co_await SendMethodCall(method, json_params);
+  auto result = co_await RpcEndpoint::SendMethodCall(method, json_params);
   if (!result) {
+    spdlog::error("RpcEndpoint failed to send method call: {}", method);
     co_return std::unexpected(result.error());
   }
 
   try {
     co_return result->template get<ResultType>();
   } catch (const nlohmann::json::exception &ex) {
+    spdlog::error("RpcEndpoint failed to convert result: {}", ex.what());
     co_return error::CreateClientError(
         "Failed to convert result: " + std::string(ex.what()));
   }
@@ -149,17 +166,25 @@ auto RpcEndpoint::SendMethodCall(std::string method, ParamsType params)
 
 template <typename ParamsType>
 auto RpcEndpoint::SendNotification(std::string method, ParamsType params)
-    -> asio::awaitable<std::expected<void, RpcError>> {
+    -> asio::awaitable<std::expected<void, RpcError>>
+  requires(
+      !std::is_same_v<std::decay_t<ParamsType>, nlohmann::json> &&
+      !std::is_same_v<std::decay_t<ParamsType>, std::optional<nlohmann::json>>)
+{
+  spdlog::debug("RpcEndpoint sending typed notification: {}", method);
   nlohmann::json json_params;
   try {
     json_params = params;
   } catch (const nlohmann::json::exception &ex) {
+    spdlog::error(
+        "RpcEndpoint failed to convert notification parameters: {}", ex.what());
     co_return error::CreateClientError(
         "Failed to convert notification parameters: " + std::string(ex.what()));
   }
 
-  auto result = co_await SendNotification(method, json_params);
+  auto result = co_await RpcEndpoint::SendNotification(method, json_params);
   if (!result) {
+    spdlog::error("RpcEndpoint failed to send notification: {}", method);
     co_return std::unexpected(result.error());
   }
 

--- a/include/jsonrpc/endpoint/endpoint.hpp
+++ b/include/jsonrpc/endpoint/endpoint.hpp
@@ -163,7 +163,7 @@ auto RpcEndpoint::SendNotification(std::string method, ParamsType params)
     co_return std::unexpected(result.error());
   }
 
-  co_return {};
+  co_return std::expected<void, RpcError>{};
 }
 
 template <typename ParamsType, typename ResultType>

--- a/src/endpoint/dispatcher.cpp
+++ b/src/endpoint/dispatcher.cpp
@@ -27,9 +27,8 @@ void Dispatcher::RegisterNotification(
 auto Dispatcher::DispatchRequest(std::string request)
     -> asio::awaitable<std::optional<std::string>> {
   nlohmann::json root;
-  try {
-    root = nlohmann::json::parse(request);
-  } catch (const nlohmann::json::parse_error& e) {
+  root = nlohmann::json::parse(request, nullptr, false);
+  if (root.is_discarded()) {
     co_return Response::CreateError(ErrorCode::kParseError).ToJson().dump();
   }
 

--- a/src/endpoint/endpoint.cpp
+++ b/src/endpoint/endpoint.cpp
@@ -39,11 +39,11 @@ auto RpcEndpoint::CreateClient(
 }
 
 auto RpcEndpoint::Start() -> asio::awaitable<std::expected<void, RpcError>> {
+  spdlog::debug("RpcEndpoint starting");
   if (is_running_.exchange(true)) {
     co_return CreateClientError("RPC endpoint is already running");
   }
 
-  spdlog::debug("Starting RPC endpoint");
   pending_requests_.clear();
 
   // Start the transport
@@ -66,14 +66,8 @@ auto RpcEndpoint::WaitForShutdown()
     co_return std::expected<void, RpcError>{};
   }
 
-  // Create a timer to check if the service is running
-  auto executor = co_await asio::this_coro::executor;
-  asio::steady_timer timer(executor, std::chrono::milliseconds(100));
-
-  // Check periodically until shutdown is complete
-  while (is_running_) {
-    co_await timer.async_wait(asio::use_awaitable);
-    timer.expires_after(std::chrono::milliseconds(100));
+  if (message_loop_.valid()) {
+    co_await std::move(message_loop_);
   }
 
   co_return std::expected<void, RpcError>{};
@@ -122,6 +116,7 @@ auto RpcEndpoint::SendMethodCall(
   Request request(method, std::move(params), request_id);
   std::string message = request.ToJson().dump();
 
+  spdlog::debug("RpcEndpoint sending message: {}", message.substr(0, 100));
   auto pending_request = std::make_shared<PendingRequest>(endpoint_strand_);
   asio::post(endpoint_strand_, [this, request_id, pending_request] {
     pending_requests_[request_id] = pending_request;
@@ -151,6 +146,7 @@ auto RpcEndpoint::SendNotification(
   Request request(method, std::move(params));
   std::string message = request.ToJson().dump();
 
+  spdlog::debug("RpcEndpoint sending message: {}", message.substr(0, 100));
   auto send_result = co_await transport_->SendMessage(message);
   if (!send_result) {
     co_return std::unexpected(send_result.error());
@@ -175,9 +171,15 @@ auto RpcEndpoint::HasPendingRequests() const -> bool {
 }
 
 void RpcEndpoint::StartMessageProcessing() {
+  spdlog::debug("Endpoint starting message processing");
   message_loop_ = asio::co_spawn(
       endpoint_strand_,
-      [this] { return this->ProcessMessagesLoop(cancel_signal_.slot()); },
+      [this] {
+        spdlog::debug(
+            "Endpoint starting message processing, is_running_: {}",
+            is_running_.load());
+        return this->ProcessMessagesLoop(cancel_signal_.slot());
+      },
       asio::use_awaitable);
 }
 
@@ -191,7 +193,13 @@ auto RetryDelay(asio::any_io_executor exec) -> asio::awaitable<void> {
 auto RpcEndpoint::ProcessMessagesLoop(asio::cancellation_slot slot)
     -> asio::awaitable<void> {
   auto state = co_await asio::this_coro::cancellation_state;
+
+  // log is_running_ and state.cancelled()
+  spdlog::debug(
+      "Endpoint processing messages loop, is_running_: {}, !cancelled: {}",
+      is_running_.load(), !state.cancelled());
   while (is_running_ && !state.cancelled()) {
+    spdlog::debug("Endpoint processing messages loop");
     auto message_result = co_await transport_->ReceiveMessage();
     if (!message_result) {
       spdlog::error("Receive error: {}", message_result.error().message);
@@ -217,6 +225,7 @@ auto IsResponse(const nlohmann::json &msg) -> bool {
 
 auto RpcEndpoint::HandleMessage(std::string message)
     -> asio::awaitable<std::expected<void, RpcError>> {
+  spdlog::debug("RpcEndpoint handling message: {}", message.substr(0, 100));
   const auto json_message_result =
       nlohmann::json::parse(message, nullptr, false);
   if (json_message_result.is_discarded()) {

--- a/src/endpoint/endpoint.cpp
+++ b/src/endpoint/endpoint.cpp
@@ -139,7 +139,9 @@ auto RpcEndpoint::SendMethodCall(
 auto RpcEndpoint::SendNotification(
     std::string method, std::optional<nlohmann::json> params)
     -> asio::awaitable<std::expected<void, RpcError>> {
+  spdlog::debug("RpcEndpoint sending notification: {}", method);
   if (!is_running_) {
+    spdlog::error("RpcEndpoint sending notification failed: {}", method);
     co_return CreateClientError("RPC endpoint is not running");
   }
 
@@ -171,12 +173,12 @@ auto RpcEndpoint::HasPendingRequests() const -> bool {
 }
 
 void RpcEndpoint::StartMessageProcessing() {
-  spdlog::debug("Endpoint starting message processing");
+  spdlog::debug("RpcEndpoint starting message processing");
   message_loop_ = asio::co_spawn(
       endpoint_strand_,
       [this] {
         spdlog::debug(
-            "Endpoint starting message processing, is_running_: {}",
+            "RpcEndpoint starting message processing, is_running_: {}",
             is_running_.load());
         return this->ProcessMessagesLoop(cancel_signal_.slot());
       },
@@ -196,10 +198,10 @@ auto RpcEndpoint::ProcessMessagesLoop(asio::cancellation_slot slot)
 
   // log is_running_ and state.cancelled()
   spdlog::debug(
-      "Endpoint processing messages loop, is_running_: {}, !cancelled: {}",
+      "RpcEndpoint processing messages loop, is_running_: {}, !cancelled: {}",
       is_running_.load(), !state.cancelled());
   while (is_running_ && !state.cancelled()) {
-    spdlog::debug("Endpoint processing messages loop");
+    spdlog::debug("RpcEndpoint processing messages loop");
     auto message_result = co_await transport_->ReceiveMessage();
     if (!message_result) {
       spdlog::error("Receive error: {}", message_result.error().message);


### PR DESCRIPTION
## Bug fix

Add `requires` clauses to typed `SendMethodCall` and `SendNotification` to prevent infinite recursion due to overload resolution.

## Enhancements

Improve logging throughout the transport and endpoint layers to aid debugging and traceability.
