### PR TITLE
Refactor error handling to use RpcErrorCode and RpcError

### DIFF
--- a/include/jsonrpc/endpoint/endpoint.hpp
+++ b/include/jsonrpc/endpoint/endpoint.hpp
@@ -19,9 +19,8 @@
 
 namespace jsonrpc::endpoint {
 
+using jsonrpc::error::Ok;
 using jsonrpc::error::RpcError;
-
-using ErrorHandler = std::function<void(ErrorCode, const std::string &)>;
 
 class RpcEndpoint {
  public:
@@ -120,8 +119,6 @@ class RpcEndpoint {
 
   std::atomic<bool> is_running_{false};
 
-  ErrorHandler error_handler_;
-
   asio::strand<asio::any_io_executor> endpoint_strand_;
 
   std::atomic<int64_t> next_request_id_{0};
@@ -145,8 +142,10 @@ auto RpcEndpoint::SendMethodCall(std::string method, ParamsType params)
   } catch (const nlohmann::json::exception &ex) {
     spdlog::error(
         "RpcEndpoint failed to convert parameters to JSON: {}", ex.what());
-    co_return error::CreateClientError(
-        "Failed to convert parameters to JSON: " + std::string(ex.what()));
+    co_return RpcError::UnexpectedFromCode(
+        RpcErrorCode::kClientError,
+        "RpcEndpoint failed to convert parameters to JSON: " +
+            std::string(ex.what()));
   }
 
   auto result = co_await RpcEndpoint::SendMethodCall(method, json_params);
@@ -159,8 +158,9 @@ auto RpcEndpoint::SendMethodCall(std::string method, ParamsType params)
     co_return result->template get<ResultType>();
   } catch (const nlohmann::json::exception &ex) {
     spdlog::error("RpcEndpoint failed to convert result: {}", ex.what());
-    co_return error::CreateClientError(
-        "Failed to convert result: " + std::string(ex.what()));
+    co_return RpcError::UnexpectedFromCode(
+        RpcErrorCode::kClientError,
+        "RpcEndpoint failed to convert result: " + std::string(ex.what()));
   }
 }
 
@@ -178,8 +178,10 @@ auto RpcEndpoint::SendNotification(std::string method, ParamsType params)
   } catch (const nlohmann::json::exception &ex) {
     spdlog::error(
         "RpcEndpoint failed to convert notification parameters: {}", ex.what());
-    co_return error::CreateClientError(
-        "Failed to convert notification parameters: " + std::string(ex.what()));
+    co_return RpcError::UnexpectedFromCode(
+        RpcErrorCode::kClientError,
+        "RpcEndpoint failed to convert notification parameters: " +
+            std::string(ex.what()));
   }
 
   auto result = co_await RpcEndpoint::SendNotification(method, json_params);
@@ -188,7 +190,7 @@ auto RpcEndpoint::SendNotification(std::string method, ParamsType params)
     co_return std::unexpected(result.error());
   }
 
-  co_return std::expected<void, RpcError>{};
+  co_return Ok();
 }
 
 template <typename ParamsType, typename ResultType>

--- a/include/jsonrpc/endpoint/endpoint.hpp
+++ b/include/jsonrpc/endpoint/endpoint.hpp
@@ -150,8 +150,7 @@ auto RpcEndpoint::SendMethodCall(std::string method, ParamsType params)
 
   auto result = co_await RpcEndpoint::SendMethodCall(method, json_params);
   if (!result) {
-    spdlog::error("RpcEndpoint failed to send method call: {}", method);
-    co_return std::unexpected(result.error());
+    co_return result;
   }
 
   try {
@@ -186,8 +185,7 @@ auto RpcEndpoint::SendNotification(std::string method, ParamsType params)
 
   auto result = co_await RpcEndpoint::SendNotification(method, json_params);
   if (!result) {
-    spdlog::error("RpcEndpoint failed to send notification: {}", method);
-    co_return std::unexpected(result.error());
+    co_return result;
   }
 
   co_return Ok();

--- a/include/jsonrpc/endpoint/response.hpp
+++ b/include/jsonrpc/endpoint/response.hpp
@@ -10,8 +10,8 @@
 
 namespace jsonrpc::endpoint {
 
-using jsonrpc::error::ErrorCode;
 using jsonrpc::error::RpcError;
+using jsonrpc::error::RpcErrorCode;
 
 class Response {
  public:
@@ -31,7 +31,7 @@ class Response {
       -> Response;
 
   static auto CreateError(
-      ErrorCode code, const std::optional<RequestId>& id = std::nullopt)
+      RpcErrorCode code, const std::optional<RequestId>& id = std::nullopt)
       -> Response;
 
   static auto CreateError(

--- a/src/endpoint/endpoint.cpp
+++ b/src/endpoint/endpoint.cpp
@@ -99,7 +99,7 @@ auto RpcEndpoint::Shutdown() -> asio::awaitable<std::expected<void, RpcError>> {
   // Now close the transport
   auto close_result = co_await transport_->Close();
   if (!close_result) {
-    co_return std::unexpected(close_result.error());
+    co_return close_result;
   }
 
   co_return Ok();
@@ -153,7 +153,7 @@ auto RpcEndpoint::SendNotification(
   spdlog::debug("RpcEndpoint sending message: {}", message.substr(0, 100));
   auto send_result = co_await transport_->SendMessage(message);
   if (!send_result) {
-    co_return std::unexpected(send_result.error());
+    co_return send_result;
   }
 
   co_return std::expected<void, RpcError>{};

--- a/src/endpoint/endpoint.cpp
+++ b/src/endpoint/endpoint.cpp
@@ -9,10 +9,9 @@
 
 namespace jsonrpc::endpoint {
 
-using jsonrpc::error::CreateClientError;
-using jsonrpc::error::CreateServerError;
-using jsonrpc::error::ErrorCode;
+using jsonrpc::error::Ok;
 using jsonrpc::error::RpcError;
+using jsonrpc::error::RpcErrorCode;
 
 RpcEndpoint::RpcEndpoint(
     asio::any_io_executor executor,
@@ -41,7 +40,8 @@ auto RpcEndpoint::CreateClient(
 auto RpcEndpoint::Start() -> asio::awaitable<std::expected<void, RpcError>> {
   spdlog::debug("RpcEndpoint starting");
   if (is_running_.exchange(true)) {
-    co_return CreateClientError("RPC endpoint is already running");
+    co_return RpcError::UnexpectedFromCode(
+        RpcErrorCode::kClientError, "RPC endpoint is already running");
   }
 
   pending_requests_.clear();
@@ -49,7 +49,7 @@ auto RpcEndpoint::Start() -> asio::awaitable<std::expected<void, RpcError>> {
   // Start the transport
   auto start_result = co_await transport_->Start();
   if (!start_result) {
-    co_return std::unexpected(start_result.error());
+    co_return start_result;
   }
 
   // Start message processing on the endpoint strand
@@ -102,14 +102,15 @@ auto RpcEndpoint::Shutdown() -> asio::awaitable<std::expected<void, RpcError>> {
     co_return std::unexpected(close_result.error());
   }
 
-  co_return std::expected<void, RpcError>{};
+  co_return Ok();
 }
 
 auto RpcEndpoint::SendMethodCall(
     std::string method, std::optional<nlohmann::json> params)
     -> asio::awaitable<std::expected<nlohmann::json, RpcError>> {
   if (!is_running_) {
-    co_return CreateClientError("RPC endpoint is not running");
+    co_return RpcError::UnexpectedFromCode(
+        RpcErrorCode::kClientError, "RPC endpoint is not running");
   }
 
   auto request_id = GetNextRequestId();
@@ -130,7 +131,8 @@ auto RpcEndpoint::SendMethodCall(
   auto result = co_await pending_request->GetResult();
   if (result.contains("error")) {
     auto err = result["error"];
-    co_return CreateClientError(err["message"].get<std::string>());
+    co_return RpcError::UnexpectedFromCode(
+        RpcErrorCode::kClientError, err["message"].get<std::string>());
   }
 
   co_return result["result"];
@@ -141,8 +143,8 @@ auto RpcEndpoint::SendNotification(
     -> asio::awaitable<std::expected<void, RpcError>> {
   spdlog::debug("RpcEndpoint sending notification: {}", method);
   if (!is_running_) {
-    spdlog::error("RpcEndpoint sending notification failed: {}", method);
-    co_return CreateClientError("RPC endpoint is not running");
+    co_return RpcError::UnexpectedFromCode(
+        RpcErrorCode::kClientError, "RpcEndpoint is not running");
   }
 
   Request request(method, std::move(params));
@@ -204,14 +206,14 @@ auto RpcEndpoint::ProcessMessagesLoop(asio::cancellation_slot slot)
     spdlog::debug("RpcEndpoint processing messages loop");
     auto message_result = co_await transport_->ReceiveMessage();
     if (!message_result) {
-      spdlog::error("Receive error: {}", message_result.error().message);
+      spdlog::error("Receive error: {}", message_result.error().Message());
       co_await RetryDelay(executor_);
       continue;
     }
 
     auto handle_result = co_await HandleMessage(*message_result);
     if (!handle_result) {
-      spdlog::error("Handle error: {}", handle_result.error().message);
+      spdlog::error("Handle error: {}", handle_result.error().Message());
       co_await RetryDelay(executor_);
       continue;
     }
@@ -231,14 +233,16 @@ auto RpcEndpoint::HandleMessage(std::string message)
   const auto json_message_result =
       nlohmann::json::parse(message, nullptr, false);
   if (json_message_result.is_discarded()) {
-    co_return std::unexpected(CreateClientError("Failed to parse message"));
+    co_return RpcError::UnexpectedFromCode(
+        RpcErrorCode::kClientError, "Failed to parse message");
   }
   const auto &json_message = json_message_result;
 
   if (IsResponse(json_message)) {
     auto response = Response::FromJson(json_message);
     if (!response.has_value()) {
-      co_return std::unexpected(CreateClientError("Invalid response"));
+      co_return RpcError::UnexpectedFromCode(
+          RpcErrorCode::kClientError, "Invalid response");
     }
     co_return co_await HandleResponse(std::move(response.value()));
   }
@@ -254,8 +258,8 @@ auto RpcEndpoint::HandleResponse(Response response)
     -> asio::awaitable<std::expected<void, RpcError>> {
   auto id_opt = response.GetId();
   if (!id_opt || !std::holds_alternative<int64_t>(*id_opt)) {
-    co_return std::unexpected(
-        CreateClientError("Response ID missing or not int64"));
+    co_return RpcError::UnexpectedFromCode(
+        RpcErrorCode::kClientError, "Response ID missing or not int64");
   }
 
   const auto id = std::get<int64_t>(*id_opt);
@@ -275,8 +279,9 @@ auto RpcEndpoint::HandleResponse(Response response)
   co_await asio::post(co_await asio::this_coro::executor, asio::use_awaitable);
 
   if (!found || !request) {
-    co_return std::unexpected(
-        CreateClientError("Unknown request ID: " + std::to_string(id)));
+    co_return RpcError::UnexpectedFromCode(
+        RpcErrorCode::kClientError,
+        "Unknown request ID: " + std::to_string(id));
   }
 
   request->SetResult(response.ToJson());

--- a/src/endpoint/request.cpp
+++ b/src/endpoint/request.cpp
@@ -2,8 +2,8 @@
 
 namespace jsonrpc::endpoint {
 
-using error::ErrorCode;
 using error::RpcError;
+using error::RpcErrorCode;
 
 Request::Request(
     std::string method, std::optional<nlohmann::json> params,
@@ -30,22 +30,22 @@ Request::Request(std::string method, std::optional<nlohmann::json> params)
 
 auto Request::FromJson(const nlohmann::json& json_obj)
     -> std::expected<Request, error::RpcError> {
-  using error::ErrorCode;
   using error::RpcError;
+  using error::RpcErrorCode;
 
   if (!json_obj.is_object()) {
-    return std::unexpected(
-        RpcError{ErrorCode::kInvalidRequest, "Request must be a JSON object"});
+    return std::unexpected(RpcError{
+        RpcErrorCode::kInvalidRequest, "Request must be a JSON object"});
   }
 
   if (!json_obj.contains("jsonrpc") || json_obj["jsonrpc"] != kJsonRpcVersion) {
     return std::unexpected(RpcError{
-        ErrorCode::kInvalidRequest, "Missing or invalid 'jsonrpc' version"});
+        RpcErrorCode::kInvalidRequest, "Missing or invalid 'jsonrpc' version"});
   }
 
   if (!json_obj.contains("method") || !json_obj["method"].is_string()) {
     return std::unexpected(
-        RpcError{ErrorCode::kInvalidRequest, "Missing or invalid 'method'"});
+        RpcError{RpcErrorCode::kInvalidRequest, "Missing or invalid 'method'"});
   }
 
   auto method = json_obj["method"].get<std::string>();
@@ -57,7 +57,7 @@ auto Request::FromJson(const nlohmann::json& json_obj)
     const auto& p = json_obj["params"];
     if (!p.is_array() && !p.is_object() && !p.is_null()) {
       return std::unexpected(RpcError{
-          ErrorCode::kInvalidRequest,
+          RpcErrorCode::kInvalidRequest,
           "'params' must be object, array, or null"});
     }
   }
@@ -69,7 +69,7 @@ auto Request::FromJson(const nlohmann::json& json_obj)
   const auto& id_json = json_obj["id"];
   if (!id_json.is_string() && !id_json.is_number_integer()) {
     return std::unexpected(
-        RpcError{ErrorCode::kInvalidRequest, "Invalid 'id' type"});
+        RpcError{RpcErrorCode::kInvalidRequest, "Invalid 'id' type"});
   }
 
   RequestId id;

--- a/src/endpoint/request.cpp
+++ b/src/endpoint/request.cpp
@@ -34,18 +34,18 @@ auto Request::FromJson(const nlohmann::json& json_obj)
   using error::RpcErrorCode;
 
   if (!json_obj.is_object()) {
-    return std::unexpected(RpcError{
-        RpcErrorCode::kInvalidRequest, "Request must be a JSON object"});
+    return RpcError::UnexpectedFromCode(
+        RpcErrorCode::kInvalidRequest, "Request must be a JSON object");
   }
 
   if (!json_obj.contains("jsonrpc") || json_obj["jsonrpc"] != kJsonRpcVersion) {
-    return std::unexpected(RpcError{
-        RpcErrorCode::kInvalidRequest, "Missing or invalid 'jsonrpc' version"});
+    return RpcError::UnexpectedFromCode(
+        RpcErrorCode::kInvalidRequest, "Missing or invalid 'jsonrpc' version");
   }
 
   if (!json_obj.contains("method") || !json_obj["method"].is_string()) {
-    return std::unexpected(
-        RpcError{RpcErrorCode::kInvalidRequest, "Missing or invalid 'method'"});
+    return RpcError::UnexpectedFromCode(
+        RpcErrorCode::kInvalidRequest, "Missing or invalid 'method'");
   }
 
   auto method = json_obj["method"].get<std::string>();
@@ -56,9 +56,9 @@ auto Request::FromJson(const nlohmann::json& json_obj)
   if (json_obj.contains("params")) {
     const auto& p = json_obj["params"];
     if (!p.is_array() && !p.is_object() && !p.is_null()) {
-      return std::unexpected(RpcError{
+      return RpcError::UnexpectedFromCode(
           RpcErrorCode::kInvalidRequest,
-          "'params' must be object, array, or null"});
+          "'params' must be object, array, or null");
     }
   }
 
@@ -68,8 +68,8 @@ auto Request::FromJson(const nlohmann::json& json_obj)
 
   const auto& id_json = json_obj["id"];
   if (!id_json.is_string() && !id_json.is_number_integer()) {
-    return std::unexpected(
-        RpcError{RpcErrorCode::kInvalidRequest, "Invalid 'id' type"});
+    return RpcError::UnexpectedFromCode(
+        RpcErrorCode::kInvalidRequest, "Invalid 'id' type");
   }
 
   RequestId id;

--- a/tests/endpoint/dispatcher_test.cpp
+++ b/tests/endpoint/dispatcher_test.cpp
@@ -7,7 +7,7 @@
 #include <spdlog/spdlog.h>
 
 using jsonrpc::endpoint::Dispatcher;
-using jsonrpc::error::ErrorCode;
+using jsonrpc::error::RpcErrorCode;
 
 // Helper function for running dispatcher tests
 template <typename TestFunc>
@@ -105,7 +105,7 @@ TEST_CASE("Batch request handling", "[Dispatcher]") {
       auto result = nlohmann::json::parse(*response);
       REQUIRE(
           result["error"]["code"] ==
-          static_cast<int>(ErrorCode::kInvalidRequest));
+          static_cast<int>(RpcErrorCode::kInvalidRequest));
       co_return;
     });
   }
@@ -120,7 +120,7 @@ TEST_CASE("Batch request handling", "[Dispatcher]") {
       REQUIRE(result.size() == 1);
       REQUIRE(
           result[0]["error"]["code"] ==
-          static_cast<int>(ErrorCode::kInvalidRequest));
+          static_cast<int>(RpcErrorCode::kInvalidRequest));
       co_return;
     });
   }
@@ -140,7 +140,7 @@ TEST_CASE("Error handling", "[Dispatcher]") {
       auto result = nlohmann::json::parse(*response);
       REQUIRE(
           result["error"]["code"] ==
-          static_cast<int>(ErrorCode::kMethodNotFound));
+          static_cast<int>(RpcErrorCode::kMethodNotFound));
       co_return;
     });
   }
@@ -154,7 +154,7 @@ TEST_CASE("Error handling", "[Dispatcher]") {
       auto result = nlohmann::json::parse(*response);
       REQUIRE(
           result["error"]["code"] ==
-          static_cast<int>(ErrorCode::kInvalidRequest));
+          static_cast<int>(RpcErrorCode::kInvalidRequest));
     });
   }
 
@@ -165,7 +165,8 @@ TEST_CASE("Error handling", "[Dispatcher]") {
       REQUIRE(response.has_value());
       auto result = nlohmann::json::parse(*response);
       REQUIRE(
-          result["error"]["code"] == static_cast<int>(ErrorCode::kParseError));
+          result["error"]["code"] ==
+          static_cast<int>(RpcErrorCode::kParseError));
     });
   }
 
@@ -176,7 +177,8 @@ TEST_CASE("Error handling", "[Dispatcher]") {
       REQUIRE(response.has_value());
       auto result = nlohmann::json::parse(*response);
       REQUIRE(
-          result["error"]["code"] == static_cast<int>(ErrorCode::kParseError));
+          result["error"]["code"] ==
+          static_cast<int>(RpcErrorCode::kParseError));
     });
   }
 
@@ -195,7 +197,7 @@ TEST_CASE("Error handling", "[Dispatcher]") {
       auto result = nlohmann::json::parse(*response);
       REQUIRE(
           result["error"]["code"] ==
-          static_cast<int>(ErrorCode::kInternalError));
+          static_cast<int>(RpcErrorCode::kInternalError));
     });
   }
 }

--- a/tests/endpoint/endpoint_test.cpp
+++ b/tests/endpoint/endpoint_test.cpp
@@ -77,7 +77,7 @@ TEST_CASE("RpcEndpoint - Basic lifecycle", "[endpoint]") {
       auto start_result2 = co_await endpoint->Start();
       REQUIRE_FALSE(start_result2);
       REQUIRE(
-          start_result2.error().message == "RPC endpoint is already running");
+          start_result2.error().Message() == "RPC endpoint is already running");
 
       // Shutdown should work
       auto shutdown_result = co_await endpoint->Shutdown();

--- a/tests/endpoint/request_test.cpp
+++ b/tests/endpoint/request_test.cpp
@@ -5,7 +5,7 @@
 
 using jsonrpc::endpoint::Request;
 using jsonrpc::endpoint::RequestId;
-using jsonrpc::error::ErrorCode;
+using jsonrpc::error::RpcErrorCode;
 
 TEST_CASE("Request construction and basic properties", "[Request]") {
   SECTION("Create request with all parameters") {
@@ -126,7 +126,7 @@ TEST_CASE("Request validation", "[Request]") {
         {"jsonrpc", "1.0"}, {"method", "test_method"}, {"id", 1}};
     auto request = Request::FromJson(json);
     REQUIRE_FALSE(request.has_value());
-    REQUIRE(request.error().code == ErrorCode::kInvalidRequest);
+    REQUIRE(request.error().Code() == RpcErrorCode::kInvalidRequest);
   }
 
   SECTION("Missing method") {
@@ -134,14 +134,14 @@ TEST_CASE("Request validation", "[Request]") {
         {"jsonrpc", "2.0"}, {"params", {{"param", "value"}}}, {"id", 1}};
     auto request = Request::FromJson(json);
     REQUIRE_FALSE(request.has_value());
-    REQUIRE(request.error().code == ErrorCode::kInvalidRequest);
+    REQUIRE(request.error().Code() == RpcErrorCode::kInvalidRequest);
   }
 
   SECTION("Invalid method type") {
     nlohmann::json json = {{"jsonrpc", "2.0"}, {"method", 123}, {"id", 1}};
     auto request = Request::FromJson(json);
     REQUIRE_FALSE(request.has_value());
-    REQUIRE(request.error().code == ErrorCode::kInvalidRequest);
+    REQUIRE(request.error().Code() == RpcErrorCode::kInvalidRequest);
   }
 
   SECTION("Invalid params type") {
@@ -152,6 +152,6 @@ TEST_CASE("Request validation", "[Request]") {
         {"id", 1}};
     auto request = Request::FromJson(json);
     REQUIRE_FALSE(request.has_value());
-    REQUIRE(request.error().code == ErrorCode::kInvalidRequest);
+    REQUIRE(request.error().Code() == RpcErrorCode::kInvalidRequest);
   }
 }

--- a/tests/transports/framed_pipe_transport_test.cpp
+++ b/tests/transports/framed_pipe_transport_test.cpp
@@ -458,7 +458,7 @@ TEST_CASE(
     auto result = co_await framed_receiver->ReceiveMessage();
     REQUIRE(!result.has_value());
     REQUIRE(
-        result.error().message.find("Invalid Content-Length header") !=
+        result.error().Message().find("Invalid Content-Length header") !=
         std::string::npos);
 
     co_await raw_sender->Close();
@@ -506,7 +506,7 @@ TEST_CASE(
     auto result = co_await framed_receiver->ReceiveMessage();
     REQUIRE(!result.has_value());
     REQUIRE(
-        result.error().message.find("Missing Content-Length header") !=
+        result.error().Message().find("Missing Content-Length header") !=
         std::string::npos);
 
     co_await raw_sender->Close();


### PR DESCRIPTION
## Summary

Simplified and standardized error handling across the JSON-RPC stack by replacing legacy error types and helpers with a unified `RpcError` and `RpcErrorCode` system.

## Key Changes

- Replaced `ErrorCode` with `RpcErrorCode`.
- Removed `CreateClientError`, `CreateTransportError`, and similar helpers.
- Centralized error creation via `RpcError::FromCode` and `RpcError::UnexpectedFromCode`.
- Replaced legacy structs (`ClientError`, `TransportError`, etc.) with a unified `RpcError` class.
- Updated all call sites and tests accordingly.
