### PR TITLE
Add kUnknownError to RpcErrorCode enum

### DIFF
--- a/include/jsonrpc/error/error.hpp
+++ b/include/jsonrpc/error/error.hpp
@@ -94,10 +94,7 @@ class RpcError {
 
   static auto UnexpectedFromCode(RpcErrorCode code, std::string message = "")
       -> std::unexpected<RpcError> {
-    if (message.empty()) {
-      message = std::string(detail::DefaultMessageFor(code));
-    }
-    return std::unexpected(RpcError(code, std::move(message)));
+    return std::unexpected(RpcError::FromCode(code, std::move(message)));
   }
 
  private:

--- a/include/jsonrpc/error/error.hpp
+++ b/include/jsonrpc/error/error.hpp
@@ -22,6 +22,9 @@ enum class RpcErrorCode {
 
   // Client errors
   kClientError = -32099,
+
+  // Unknown error
+  kUnknownError = -32098,
 };
 
 namespace detail {
@@ -45,8 +48,9 @@ inline auto DefaultMessageFor(RpcErrorCode code) -> std::string_view {
       return "Timeout error";
     case RpcErrorCode::kClientError:
       return "Client error";
+    case RpcErrorCode::kUnknownError:
+      return "Unknown error";
   }
-  return "Unknown error";
 }
 }  // namespace detail
 


### PR DESCRIPTION
## Summary

Introduced a new RpcErrorCode value `kUnknownError` with code -32098 to represent uncategorized errors.

## Details

- Added `kUnknownError` to the `RpcErrorCode` enum.
- Updated `DefaultMessageFor` to return "Unknown error" for this new code.
