### PR TITLE
Refactor traits and constraints for better error type handling

### DIFF
--- a/include/jsonrpc/endpoint/endpoint.hpp
+++ b/include/jsonrpc/endpoint/endpoint.hpp
@@ -12,7 +12,7 @@
 #include <spdlog/spdlog.h>
 
 #include "jsonrpc/endpoint/dispatcher.hpp"
-#include "jsonrpc/endpoint/json_trait.hpp"
+#include "jsonrpc/endpoint/jsonrpc_traits.hpp"
 #include "jsonrpc/endpoint/pending_request.hpp"
 #include "jsonrpc/endpoint/response.hpp"
 #include "jsonrpc/endpoint/typed_handlers.hpp"
@@ -95,7 +95,7 @@ class RpcEndpoint {
       std::string method,
       std::function<asio::awaitable<std::expected<void, ErrorType>>(ParamsType)>
           handler)
-    requires(FromJson<ParamsType>);
+    requires(FromJson<ParamsType> && HasMessageMethod<ErrorType>);
 
   [[nodiscard]] auto HasPendingRequests() const -> bool;
 
@@ -240,7 +240,7 @@ void RpcEndpoint::RegisterNotification(
     std::string method,
     std::function<asio::awaitable<std::expected<void, ErrorType>>(ParamsType)>
         handler)
-  requires(FromJson<ParamsType>)
+  requires(FromJson<ParamsType> && HasMessageMethod<ErrorType>)
 {
   // Create a handler object and store its function object
   // NOTE: Using a class-based approach with shared_ptr ownership guarantees

--- a/include/jsonrpc/endpoint/jsonrpc_traits.hpp
+++ b/include/jsonrpc/endpoint/jsonrpc_traits.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <concepts>
+#include <variant>
 
 #include "nlohmann/json.hpp"
 
@@ -12,7 +13,7 @@ concept FromJson = requires(nlohmann::json j) {
 };
 
 template <typename T>
-concept ToJson = requires(T value) {
+concept ToJson = std::is_same_v<T, std::monostate> || requires(T value) {
   { nlohmann::json(value) } -> std::same_as<nlohmann::json>;
 };
 
@@ -23,5 +24,10 @@ template <typename T>
 concept NotJsonLike =
     !std::is_same_v<std::decay_t<T>, nlohmann::json> &&
     !std::is_same_v<std::decay_t<T>, std::optional<nlohmann::json>>;
+
+template <typename T>
+concept HasMessageMethod = std::is_same_v<T, std::monostate> || requires(T e) {
+  { e.Message() } -> std::convertible_to<std::string>;
+};
 
 }  // namespace jsonrpc::endpoint


### PR DESCRIPTION
## Summary

Improves the handling of notification and method handler constraints to allow `std::monostate` as a valid non-error type, while enforcing `ToJson` or `.Message()` presence when appropriate.

## Changes

- Renamed `json_trait.hpp` to `jsonrpc_traits.hpp` for clarity.
- Modified `ToJson` and added `HasMessageMethod` to explicitly allow `std::monostate`.
- Applied stricter requires clauses to constrain handler templates based on error type capabilities.
- Enhanced logging in `TypedNotificationHandler` with error message output.
