### PR TITLE
Improve logging clarity and consistency across RPC components

### DIFF
--- a/src/endpoint/dispatcher.cpp
+++ b/src/endpoint/dispatcher.cpp
@@ -84,6 +84,8 @@ auto Dispatcher::DispatchSingleRequest(Request request)
   if (request.IsNotification()) {
     auto it = notification_handlers_.find(method);
     if (it != notification_handlers_.end()) {
+      spdlog::debug(
+          "Dispatcher found notification handler for method: {}", method);
       co_spawn(
           executor_,
           [handler = it->second, params = request.GetParams()] {
@@ -91,11 +93,14 @@ auto Dispatcher::DispatchSingleRequest(Request request)
           },
           asio::detached);
     }
+    spdlog::debug(
+        "Dispatcher notification handler not found for method: {}", method);
     co_return std::nullopt;
   }
 
   auto it = method_handlers_.find(method);
   if (it != method_handlers_.end()) {
+    spdlog::debug("Dispatcher found method handler for method: {}", method);
     auto result = co_await asio::co_spawn(
         executor_,
         [handler = it->second, params = request.GetParams()] {
@@ -104,7 +109,7 @@ auto Dispatcher::DispatchSingleRequest(Request request)
         asio::use_awaitable);
     co_return Response::CreateSuccess(result, request.GetId());
   }
-
+  spdlog::debug("Dispatcher method handler not found for method: {}", method);
   co_return Response::CreateError(
       RpcErrorCode::kMethodNotFound, request.GetId());
 }

--- a/src/endpoint/endpoint.cpp
+++ b/src/endpoint/endpoint.cpp
@@ -117,7 +117,7 @@ auto RpcEndpoint::SendMethodCall(
   Request request(method, std::move(params), request_id);
   std::string message = request.ToJson().dump();
 
-  spdlog::debug("RpcEndpoint sending message: {}", message.substr(0, 100));
+  spdlog::debug("RpcEndpoint sending message: {}", message.substr(0, 70));
   auto pending_request = std::make_shared<PendingRequest>(endpoint_strand_);
   asio::post(endpoint_strand_, [this, request_id, pending_request] {
     pending_requests_[request_id] = pending_request;
@@ -150,7 +150,7 @@ auto RpcEndpoint::SendNotification(
   Request request(method, std::move(params));
   std::string message = request.ToJson().dump();
 
-  spdlog::debug("RpcEndpoint sending message: {}", message.substr(0, 100));
+  spdlog::debug("RpcEndpoint sending message: {}", message.substr(0, 70));
   auto send_result = co_await transport_->SendMessage(message);
   if (!send_result) {
     co_return send_result;
@@ -198,12 +198,7 @@ auto RpcEndpoint::ProcessMessagesLoop(asio::cancellation_slot slot)
     -> asio::awaitable<void> {
   auto state = co_await asio::this_coro::cancellation_state;
 
-  // log is_running_ and state.cancelled()
-  spdlog::debug(
-      "RpcEndpoint processing messages loop, is_running_: {}, !cancelled: {}",
-      is_running_.load(), !state.cancelled());
   while (is_running_ && !state.cancelled()) {
-    spdlog::debug("RpcEndpoint processing messages loop");
     auto message_result = co_await transport_->ReceiveMessage();
     if (!message_result) {
       spdlog::error("Receive error: {}", message_result.error().Message());
@@ -229,7 +224,7 @@ auto IsResponse(const nlohmann::json &msg) -> bool {
 
 auto RpcEndpoint::HandleMessage(std::string message)
     -> asio::awaitable<std::expected<void, RpcError>> {
-  spdlog::debug("RpcEndpoint handling message: {}", message.substr(0, 100));
+  spdlog::debug("RpcEndpoint handling message: {}", message.substr(0, 70));
   const auto json_message_result =
       nlohmann::json::parse(message, nullptr, false);
   if (json_message_result.is_discarded()) {

--- a/src/transport/pipe_transport.cpp
+++ b/src/transport/pipe_transport.cpp
@@ -1,5 +1,6 @@
 #include "jsonrpc/transport/pipe_transport.hpp"
 
+#include <algorithm>
 #include <filesystem>
 #include <string>
 
@@ -314,7 +315,13 @@ auto PipeTransport::ReceiveMessage()
   }
 
   message_buffer_.append(read_buffer_.data(), bytes_read);
-  spdlog::debug("PipeTransport received message: {}", message_buffer_);
+  auto log_message = message_buffer_;
+  if (log_message.size() > 70) {
+    log_message = log_message.substr(0, 70) + "...";
+  }
+  std::ranges::replace(log_message, '\n', ' ');
+  std::ranges::replace(log_message, '\r', ' ');
+  spdlog::debug("PipeTransport received message: {}", log_message);
   co_return std::move(message_buffer_);
 }
 


### PR DESCRIPTION
## Overview

Enhanced debug logging in Dispatcher, RpcEndpoint, and PipeTransport to make logs more concise and readable.

## Details

- Added method-specific log messages in Dispatcher for better traceability.
- Shortened logged message previews from 100 to 70 characters to reduce verbosity.
- Removed repetitive or redundant loop logging in message processing.
- Cleaned and truncated logs in PipeTransport to avoid multiline log noise.
