### PR TITLE
Introduce logger injection and remove global spdlog usage

### DIFF
--- a/include/jsonrpc/endpoint/dispatcher.hpp
+++ b/include/jsonrpc/endpoint/dispatcher.hpp
@@ -8,6 +8,7 @@
 
 #include <asio.hpp>
 #include <nlohmann/json.hpp>
+#include <spdlog/spdlog.h>
 
 #include "jsonrpc/endpoint/request.hpp"
 #include "jsonrpc/endpoint/response.hpp"
@@ -21,13 +22,19 @@ class Dispatcher {
   using NotificationHandler = std::function<asio::awaitable<void>(
       const std::optional<nlohmann::json>&)>;
 
-  explicit Dispatcher(asio::any_io_executor executor);
+  explicit Dispatcher(
+      asio::any_io_executor executor,
+      std::shared_ptr<spdlog::logger> logger = nullptr);
 
   Dispatcher(const Dispatcher&) = delete;
   Dispatcher(Dispatcher&&) = delete;
   auto operator=(const Dispatcher&) -> Dispatcher& = delete;
   auto operator=(Dispatcher&&) -> Dispatcher& = delete;
   virtual ~Dispatcher() = default;
+
+  auto Logger() -> spdlog::logger& {
+    return *logger_;
+  }
 
   void RegisterMethodCall(
       const std::string& method, const MethodCallHandler& handler);
@@ -50,6 +57,8 @@ class Dispatcher {
   std::unordered_map<std::string, NotificationHandler> notification_handlers_;
 
   asio::any_io_executor executor_;
+
+  std::shared_ptr<spdlog::logger> logger_;
 };
 
 }  // namespace jsonrpc::endpoint

--- a/include/jsonrpc/endpoint/endpoint.hpp
+++ b/include/jsonrpc/endpoint/endpoint.hpp
@@ -27,7 +27,8 @@ class RpcEndpoint {
  public:
   explicit RpcEndpoint(
       asio::any_io_executor executor,
-      std::unique_ptr<transport::Transport> transport);
+      std::unique_ptr<transport::Transport> transport,
+      std::shared_ptr<spdlog::logger> logger = nullptr);
 
   static auto CreateClient(
       asio::any_io_executor executor,
@@ -49,6 +50,10 @@ class RpcEndpoint {
 
   [[nodiscard]] auto IsRunning() const -> bool {
     return is_running_.load();
+  }
+
+  auto Logger() -> spdlog::logger & {
+    return *logger_;
   }
 
   auto SendMethodCall(
@@ -114,6 +119,8 @@ class RpcEndpoint {
   auto GetNextRequestId() -> int64_t {
     return next_request_id_++;
   }
+
+  std::shared_ptr<spdlog::logger> logger_;
 
   asio::any_io_executor executor_;
 

--- a/include/jsonrpc/transport/transport.hpp
+++ b/include/jsonrpc/transport/transport.hpp
@@ -8,24 +8,14 @@
 
 #include "jsonrpc/error/error.hpp"
 
-namespace jsonrpc::detail {
-
-inline auto GetTransportLogger() -> std::shared_ptr<spdlog::logger> {
-  auto logger = spdlog::get("transport");
-  if (!logger) {
-    logger = spdlog::default_logger();
-  }
-  return logger;
-}
-
-}  // namespace jsonrpc::detail
-
 namespace jsonrpc::transport {
 
 class Transport {
  public:
-  explicit Transport(asio::any_io_executor executor)
-      : logger_(jsonrpc::detail::GetTransportLogger()),
+  explicit Transport(
+      asio::any_io_executor executor,
+      std::shared_ptr<spdlog::logger> logger = nullptr)
+      : logger_(logger ? logger : spdlog::default_logger()),
         executor_(std::move(executor)),
         strand_(asio::make_strand(executor_)) {
   }

--- a/include/jsonrpc/transport/transport.hpp
+++ b/include/jsonrpc/transport/transport.hpp
@@ -4,15 +4,30 @@
 #include <string>
 
 #include <asio.hpp>
+#include <spdlog/spdlog.h>
 
 #include "jsonrpc/error/error.hpp"
+
+namespace jsonrpc::detail {
+
+inline auto GetTransportLogger() -> std::shared_ptr<spdlog::logger> {
+  auto logger = spdlog::get("transport");
+  if (!logger) {
+    logger = spdlog::default_logger();
+  }
+  return logger;
+}
+
+}  // namespace jsonrpc::detail
 
 namespace jsonrpc::transport {
 
 class Transport {
  public:
   explicit Transport(asio::any_io_executor executor)
-      : executor_(std::move(executor)), strand_(asio::make_strand(executor_)) {
+      : logger_(jsonrpc::detail::GetTransportLogger()),
+        executor_(std::move(executor)),
+        strand_(asio::make_strand(executor_)) {
   }
 
   Transport(const Transport &) = delete;
@@ -45,7 +60,13 @@ class Transport {
     return strand_;
   }
 
+ protected:
+  auto Logger() -> spdlog::logger & {
+    return *logger_;
+  }
+
  private:
+  std::shared_ptr<spdlog::logger> logger_;
   asio::any_io_executor executor_;
   asio::strand<asio::any_io_executor> strand_;
 };

--- a/src/transport/framed_pipe_transport.cpp
+++ b/src/transport/framed_pipe_transport.cpp
@@ -30,7 +30,7 @@ auto FramedPipeTransport::ReceiveMessage()
     }
 
     if (!result.error.empty()) {
-      spdlog::error("Framing error: {}", result.error);
+      Logger().error("Framing error: {}", result.error);
       co_return RpcError::UnexpectedFromCode(
           RpcErrorCode::kTransportError, "Framing error: " + result.error);
     }

--- a/src/transport/socket_transport.cpp
+++ b/src/transport/socket_transport.cpp
@@ -1,7 +1,6 @@
 #include "jsonrpc/transport/socket_transport.hpp"
 
 #include <asio.hpp>
-#include <spdlog/spdlog.h>
 
 namespace jsonrpc::transport {
 
@@ -22,28 +21,28 @@ SocketTransport::SocketTransport(
 
 SocketTransport::~SocketTransport() {
   if (!is_closed_) {
-    spdlog::debug("SocketTransport destructor triggering CloseNow()");
+    Logger().debug("SocketTransport destructor triggering CloseNow()");
     try {
       CloseNow();
     } catch (const std::exception &e) {
-      spdlog::error("SocketTransport destructor error: {}", e.what());
+      Logger().error("SocketTransport destructor error: {}", e.what());
     }
   }
 }
 
 auto SocketTransport::Start()
     -> asio::awaitable<std::expected<void, error::RpcError>> {
-  spdlog::debug("SocketTransport starting");
+  Logger().debug("SocketTransport starting");
   co_await asio::post(GetStrand(), asio::use_awaitable);
 
   if (is_started_) {
-    spdlog::debug("SocketTransport already started");
+    Logger().debug("SocketTransport already started");
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError, "SocketTransport already started");
   }
 
   if (is_closed_) {
-    spdlog::error("SocketTransport cannot start a closed transport");
+    Logger().error("SocketTransport cannot start a closed transport");
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError, "Cannot start a closed transport");
   }
@@ -51,57 +50,58 @@ auto SocketTransport::Start()
   std::expected<void, error::RpcError> result;
 
   if (is_server_) {
-    spdlog::debug("SocketTransport starting server at {}:{}", address_, port_);
+    Logger().debug("SocketTransport starting server at {}:{}", address_, port_);
     result = co_await BindAndListen();
     if (!result) {
-      spdlog::error(
+      Logger().error(
           "SocketTransport error starting server: {}",
           result.error().Message());
       co_return result;
     }
   } else {
-    spdlog::debug(
+    Logger().debug(
         "Connecting SocketTransport client to {}:{}", address_, port_);
     result = co_await Connect();
     if (!result) {
-      spdlog::error(
+      Logger().error(
           "SocketTransport error connecting client: {}",
           result.error().Message());
       co_return result;
     }
-    spdlog::debug("SocketTransport client connected to {}:{}", address_, port_);
+    Logger().debug(
+        "SocketTransport client connected to {}:{}", address_, port_);
   }
 
   is_started_ = true;
-  spdlog::debug("SocketTransport successfully started");
+  Logger().debug("SocketTransport successfully started");
   co_return Ok();
 }
 
 auto SocketTransport::Close()
     -> asio::awaitable<std::expected<void, error::RpcError>> {
-  spdlog::debug("SocketTransport closing");
+  Logger().debug("SocketTransport closing");
   co_await asio::post(GetStrand(), asio::use_awaitable);
 
   if (is_closed_) {
-    spdlog::debug("SocketTransport already closed");
+    Logger().debug("SocketTransport already closed");
     co_return std::expected<void, error::RpcError>{};
   }
 
   is_closed_ = true;
   is_connected_ = false;
 
-  spdlog::debug("SocketTransport closing");
+  Logger().debug("SocketTransport closing");
 
   // Cancel and close the socket safely
   std::error_code ec;
   if (socket_.is_open()) {
     socket_.cancel(ec);
     if (ec) {
-      spdlog::warn("SocketTransport error canceling socket: {}", ec.message());
+      Logger().warn("SocketTransport error canceling socket: {}", ec.message());
     }
     socket_.close(ec);
     if (ec) {
-      spdlog::warn("SocketTransport error closing socket: {}", ec.message());
+      Logger().warn("SocketTransport error closing socket: {}", ec.message());
     }
   }
 
@@ -109,16 +109,16 @@ auto SocketTransport::Close()
   if (is_server_ && acceptor_) {
     acceptor_->cancel(ec);
     if (ec) {
-      spdlog::warn(
+      Logger().warn(
           "SocketTransport error canceling acceptor: {}", ec.message());
     }
     acceptor_->close(ec);
     if (ec) {
-      spdlog::warn("SocketTransport error closing acceptor: {}", ec.message());
+      Logger().warn("SocketTransport error closing acceptor: {}", ec.message());
     }
   }
 
-  spdlog::debug("SocketTransport closed");
+  Logger().debug("SocketTransport closed");
   co_return Ok();
 }
 
@@ -130,13 +130,13 @@ void SocketTransport::CloseNow() {
     if (!socket_.is_open()) {
       return;
     }
-    spdlog::debug("SocketTransport closing socket synchronously");
+    Logger().debug("SocketTransport closing socket synchronously");
 
     std::error_code ec;
     socket_.cancel();
     socket_.close(ec);
     if (ec) {
-      spdlog::warn("SocketTransport error closing socket: {}", ec.message());
+      Logger().warn("SocketTransport error closing socket: {}", ec.message());
     }
   };
 
@@ -144,13 +144,13 @@ void SocketTransport::CloseNow() {
     if (!is_server_ || !acceptor_ || !acceptor_->is_open()) {
       return;
     }
-    spdlog::debug("SocketTransport closing acceptor synchronously");
+    Logger().debug("SocketTransport closing acceptor synchronously");
 
     std::error_code ec;
     acceptor_->cancel();
     acceptor_->close(ec);
     if (ec) {
-      spdlog::warn("SocketTransport error closing acceptor: {}", ec.message());
+      Logger().warn("SocketTransport error closing acceptor: {}", ec.message());
     }
   };
 
@@ -158,7 +158,7 @@ void SocketTransport::CloseNow() {
     try_close_socket();
     try_close_acceptor();
   } catch (const std::exception &e) {
-    spdlog::error("SocketTransport error during CloseNow(): {}", e.what());
+    Logger().error("SocketTransport error during CloseNow(): {}", e.what());
   }
 }
 
@@ -192,7 +192,7 @@ auto SocketTransport::SendMessage(std::string message)
       socket_, asio::buffer(message),
       asio::redirect_error(asio::use_awaitable, ec));
   if (ec) {
-    spdlog::error("SocketTransport SendMessage failed: {}", ec.message());
+    Logger().error("SocketTransport SendMessage failed: {}", ec.message());
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError,
         "Error sending message: " + ec.message());
@@ -206,7 +206,7 @@ auto SocketTransport::ReceiveMessage()
   co_await asio::post(GetStrand(), asio::use_awaitable);
 
   if (is_closed_) {
-    spdlog::warn(
+    Logger().warn(
         "SocketTransport ReceiveMessage() called after transport was closed");
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError,
@@ -220,7 +220,7 @@ auto SocketTransport::ReceiveMessage()
   }
 
   if (!socket_.is_open()) {
-    spdlog::warn("SocketTransport ReceiveMessage() socket not open");
+    Logger().warn("SocketTransport ReceiveMessage() socket not open");
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError, "Socket not open in ReceiveMessage()");
   }
@@ -234,16 +234,16 @@ auto SocketTransport::ReceiveMessage()
 
   if (ec) {
     if (ec == asio::error::eof) {
-      spdlog::debug("SocketTransport EOF received, connection closed by peer");
+      Logger().debug("SocketTransport EOF received, connection closed by peer");
       is_connected_ = false;
       co_return RpcError::UnexpectedFromCode(
           RpcErrorCode::kTransportError, "Connection closed by peer");
     } else if (ec == asio::error::operation_aborted) {
-      spdlog::debug("SocketTransport Read operation aborted");
+      Logger().debug("SocketTransport Read operation aborted");
       co_return RpcError::UnexpectedFromCode(
           RpcErrorCode::kTransportError, "Receive operation aborted");
     } else {
-      spdlog::error(
+      Logger().error(
           "SocketTransport ASIO error in ReceiveMessage(): {}", ec.message());
       co_return RpcError::UnexpectedFromCode(
           RpcErrorCode::kTransportError, "Receive error: " + ec.message());
@@ -256,13 +256,13 @@ auto SocketTransport::ReceiveMessage()
   }
 
   message_buffer_.append(read_buffer_.data(), bytes_read);
-  spdlog::debug("SocketTransport received {} bytes", bytes_read);
+  Logger().debug("SocketTransport received {} bytes", bytes_read);
   co_return std::move(message_buffer_);
 }
 
 auto SocketTransport::Connect()
     -> asio::awaitable<std::expected<void, error::RpcError>> {
-  spdlog::debug("SocketTransport connecting to {}:{}", address_, port_);
+  Logger().debug("SocketTransport connecting to {}:{}", address_, port_);
 
   if (is_connected_) {
     co_return Ok();
@@ -278,7 +278,7 @@ auto SocketTransport::Connect()
   if (socket_.is_open()) {
     socket_.close(ec);
     if (ec) {
-      spdlog::warn(
+      Logger().warn(
           "SocketTransport error closing socket before reconnect: {}",
           ec.message());
     }
@@ -295,7 +295,7 @@ auto SocketTransport::Connect()
       address_, std::to_string(port_),
       asio::redirect_error(asio::use_awaitable, ec));
   if (ec) {
-    spdlog::error(
+    Logger().error(
         "SocketTransport error resolving {}:{}: {}", address_, port_,
         ec.message());
     co_return RpcError::UnexpectedFromCode(
@@ -306,7 +306,7 @@ auto SocketTransport::Connect()
   co_await asio::async_connect(
       socket_, endpoints, asio::redirect_error(asio::use_awaitable, ec));
   if (ec) {
-    spdlog::error(
+    Logger().error(
         "SocketTransport error connecting to {}:{}: {}", address_, port_,
         ec.message());
     if (socket_.is_open()) {
@@ -317,13 +317,13 @@ auto SocketTransport::Connect()
   }
 
   is_connected_ = true;
-  spdlog::debug("SocketTransport connected to {}:{}", address_, port_);
+  Logger().debug("SocketTransport connected to {}:{}", address_, port_);
   co_return Ok();
 }
 
 auto SocketTransport::BindAndListen()
     -> asio::awaitable<std::expected<void, error::RpcError>> {
-  spdlog::debug("SocketTransport binding to {}:{}", address_, port_);
+  Logger().debug("SocketTransport binding to {}:{}", address_, port_);
 
   asio::error_code ec;
 
@@ -337,7 +337,7 @@ auto SocketTransport::BindAndListen()
         address_, std::to_string(port_),
         asio::redirect_error(asio::use_awaitable, ec));
     if (ec) {
-      spdlog::error(
+      Logger().error(
           "SocketTransport error resolving {}:{}: {}", address_, port_,
           ec.message());
       co_return RpcError::UnexpectedFromCode(
@@ -354,14 +354,14 @@ auto SocketTransport::BindAndListen()
   // Create and open acceptor
   acceptor_->open(endpoint.protocol(), ec);
   if (ec) {
-    spdlog::error("SocketTransport error opening acceptor: {}", ec.message());
+    Logger().error("SocketTransport error opening acceptor: {}", ec.message());
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError, "Open error: " + ec.message());
   }
 
   acceptor_->set_option(asio::ip::tcp::acceptor::reuse_address(true), ec);
   if (ec) {
-    spdlog::error(
+    Logger().error(
         "SocketTransport error setting reuse_address: {}", ec.message());
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError, "Set option error: " + ec.message());
@@ -369,32 +369,32 @@ auto SocketTransport::BindAndListen()
 
   acceptor_->bind(endpoint, ec);
   if (ec) {
-    spdlog::error("SocketTransport error binding acceptor: {}", ec.message());
+    Logger().error("SocketTransport error binding acceptor: {}", ec.message());
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError, "Bind error: " + ec.message());
   }
 
   acceptor_->listen(asio::socket_base::max_listen_connections, ec);
   if (ec) {
-    spdlog::error("SocketTransport error listening: {}", ec.message());
+    Logger().error("SocketTransport error listening: {}", ec.message());
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError, "Listen error: " + ec.message());
   }
 
-  spdlog::debug("SocketTransport listening on {}:{}", address_, port_);
+  Logger().debug("SocketTransport listening on {}:{}", address_, port_);
 
   // Accept a connection
   co_await acceptor_->async_accept(
       socket_, asio::redirect_error(asio::use_awaitable, ec));
   if (ec) {
-    spdlog::error(
+    Logger().error(
         "SocketTransport error accepting connection: {}", ec.message());
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError, "Accept error: " + ec.message());
   }
 
   is_connected_ = true;
-  spdlog::debug(
+  Logger().debug(
       "SocketTransport accepted connection on {}:{}", address_, port_);
 
   co_return Ok();

--- a/tests/common/mock_transport.hpp
+++ b/tests/common/mock_transport.hpp
@@ -28,7 +28,7 @@ class MockTransport : public jsonrpc::transport::Transport {
   }
 
   ~MockTransport() override {
-    spdlog::debug("Destroying mock transport");
+    Logger().debug("Destroying mock transport");
     CloseNow();
   }
 
@@ -42,19 +42,19 @@ class MockTransport : public jsonrpc::transport::Transport {
     co_await asio::post(strand_, asio::use_awaitable);
 
     if (is_started_) {
-      spdlog::debug("MockTransport already started");
+      Logger().debug("MockTransport already started");
       co_return RpcError::UnexpectedFromCode(
           RpcErrorCode::kTransportError, "MockTransport already started");
     }
 
     if (is_closed_) {
-      spdlog::error("Cannot start a closed transport");
+      Logger().error("Cannot start a closed transport");
       co_return RpcError::UnexpectedFromCode(
           RpcErrorCode::kTransportError, "Cannot start a closed transport");
     }
 
     is_started_ = true;
-    spdlog::debug("MockTransport started");
+    Logger().debug("MockTransport started");
     co_return Ok();
   }
 
@@ -63,10 +63,10 @@ class MockTransport : public jsonrpc::transport::Transport {
     // Get strand protection
     co_await asio::post(strand_, asio::use_awaitable);
 
-    spdlog::debug("MockTransport: Closing transport");
+    Logger().debug("MockTransport: Closing transport");
 
     if (is_closed_) {
-      spdlog::debug("MockTransport: Already closed");
+      Logger().debug("MockTransport: Already closed");
       co_return std::expected<void, error::RpcError>{};
     }
 
@@ -82,7 +82,7 @@ class MockTransport : public jsonrpc::transport::Transport {
           "Failed to cancel receive timer during close: " + ec.message());
     }
 
-    spdlog::debug("MockTransport: Closed");
+    Logger().debug("MockTransport: Closed");
 
     // Optional sync point for strand tasks to flush
     co_await asio::post(strand_, asio::use_awaitable);
@@ -95,7 +95,7 @@ class MockTransport : public jsonrpc::transport::Transport {
     is_started_ = false;
     receive_timer_.cancel();
 
-    spdlog::debug("MockTransport closed synchronously");
+    Logger().debug("MockTransport closed synchronously");
   }
 
   auto SendMessage(std::string message)
@@ -120,7 +120,7 @@ class MockTransport : public jsonrpc::transport::Transport {
   auto ReceiveMessage()
       -> asio::awaitable<std::expected<std::string, error::RpcError>> override {
     if (is_closed_) {
-      spdlog::debug(
+      Logger().debug(
           "MockTransport: ReceiveMessage called after transport was closed");
       co_return RpcError::UnexpectedFromCode(
           RpcErrorCode::kTransportError,
@@ -136,7 +136,7 @@ class MockTransport : public jsonrpc::transport::Transport {
     co_await asio::post(strand_, asio::use_awaitable);
 
     if (is_closed_) {
-      spdlog::debug("MockTransport: ReceiveMessage found transport closed");
+      Logger().debug("MockTransport: ReceiveMessage found transport closed");
       co_return RpcError::UnexpectedFromCode(
           RpcErrorCode::kTransportError,
           "ReceiveMessage called after transport was closed");


### PR DESCRIPTION
## Summary

Replaces direct `spdlog` calls with structured logger injection across transport, endpoint, and dispatcher layers. This enables easier testing, flexible logging configuration, and clearer ownership.

## Changes

- Added optional `std::shared_ptr<spdlog::logger>` to `RpcEndpoint`, `Dispatcher`, and `Transport` constructors.
- Default fallback to `spdlog::default_logger()` if no logger is provided.
- Replaced all global `spdlog::debug/error/warn` calls with `Logger().debug()` style usage.
- Updated `MockTransport` and tests to follow the new logging approach.

## Rationale

This improves modularity, makes the codebase more test-friendly, and eliminates hidden global dependencies in core components.
