### PR TITLE
Switch Logger() return type to shared_ptr

### DIFF
--- a/include/jsonrpc/endpoint/dispatcher.hpp
+++ b/include/jsonrpc/endpoint/dispatcher.hpp
@@ -32,8 +32,8 @@ class Dispatcher {
   auto operator=(Dispatcher&&) -> Dispatcher& = delete;
   virtual ~Dispatcher() = default;
 
-  auto Logger() -> spdlog::logger& {
-    return *logger_;
+  auto Logger() -> std::shared_ptr<spdlog::logger> {
+    return logger_;
   }
 
   void RegisterMethodCall(

--- a/include/jsonrpc/endpoint/endpoint.hpp
+++ b/include/jsonrpc/endpoint/endpoint.hpp
@@ -52,8 +52,8 @@ class RpcEndpoint {
     return is_running_.load();
   }
 
-  auto Logger() -> spdlog::logger & {
-    return *logger_;
+  auto Logger() -> std::shared_ptr<spdlog::logger> {
+    return logger_;
   }
 
   auto SendMethodCall(

--- a/include/jsonrpc/transport/framed_pipe_transport.hpp
+++ b/include/jsonrpc/transport/framed_pipe_transport.hpp
@@ -13,7 +13,7 @@ class FramedPipeTransport : public PipeTransport {
  public:
   FramedPipeTransport(
       asio::any_io_executor executor, const std::string& socket_path,
-      bool is_server);
+      bool is_server, std::shared_ptr<spdlog::logger> logger = nullptr);
 
   auto SendMessage(std::string message)
       -> asio::awaitable<std::expected<void, error::RpcError>> override;

--- a/include/jsonrpc/transport/pipe_transport.hpp
+++ b/include/jsonrpc/transport/pipe_transport.hpp
@@ -17,7 +17,7 @@ class PipeTransport : public Transport {
  public:
   explicit PipeTransport(
       asio::any_io_executor executor, std::string socket_path,
-      bool is_server = false);
+      bool is_server = false, std::shared_ptr<spdlog::logger> logger = nullptr);
 
   ~PipeTransport() override;
 

--- a/include/jsonrpc/transport/socket_transport.hpp
+++ b/include/jsonrpc/transport/socket_transport.hpp
@@ -14,7 +14,7 @@ class SocketTransport : public Transport {
  public:
   SocketTransport(
       asio::any_io_executor executor, std::string address, uint16_t port,
-      bool is_server);
+      bool is_server, std::shared_ptr<spdlog::logger> logger = nullptr);
 
   ~SocketTransport() override;
 

--- a/include/jsonrpc/transport/transport.hpp
+++ b/include/jsonrpc/transport/transport.hpp
@@ -51,8 +51,8 @@ class Transport {
   }
 
  protected:
-  auto Logger() -> spdlog::logger & {
-    return *logger_;
+  auto Logger() -> std::shared_ptr<spdlog::logger> {
+    return logger_;
   }
 
  private:

--- a/src/endpoint/dispatcher.cpp
+++ b/src/endpoint/dispatcher.cpp
@@ -85,7 +85,7 @@ auto Dispatcher::DispatchSingleRequest(Request request)
   if (request.IsNotification()) {
     auto it = notification_handlers_.find(method);
     if (it != notification_handlers_.end()) {
-      Logger().debug(
+      Logger()->debug(
           "Dispatcher found notification handler for method: {}", method);
       co_spawn(
           executor_,
@@ -94,14 +94,14 @@ auto Dispatcher::DispatchSingleRequest(Request request)
           },
           asio::detached);
     }
-    Logger().debug(
+    Logger()->debug(
         "Dispatcher notification handler not found for method: {}", method);
     co_return std::nullopt;
   }
 
   auto it = method_handlers_.find(method);
   if (it != method_handlers_.end()) {
-    Logger().debug("Dispatcher found method handler for method: {}", method);
+    Logger()->debug("Dispatcher found method handler for method: {}", method);
     auto result = co_await asio::co_spawn(
         executor_,
         [handler = it->second, params = request.GetParams()] {
@@ -110,7 +110,7 @@ auto Dispatcher::DispatchSingleRequest(Request request)
         asio::use_awaitable);
     co_return Response::CreateSuccess(result, request.GetId());
   }
-  Logger().debug("Dispatcher method handler not found for method: {}", method);
+  Logger()->debug("Dispatcher method handler not found for method: {}", method);
   co_return Response::CreateError(
       RpcErrorCode::kMethodNotFound, request.GetId());
 }

--- a/src/endpoint/endpoint.cpp
+++ b/src/endpoint/endpoint.cpp
@@ -35,12 +35,12 @@ auto RpcEndpoint::CreateClient(
     co_return std::unexpected(start_result.error());
   }
 
-  endpoint->Logger().debug("Client endpoint initialized");
+  endpoint->Logger()->debug("Client endpoint initialized");
   co_return endpoint;
 }
 
 auto RpcEndpoint::Start() -> asio::awaitable<std::expected<void, RpcError>> {
-  Logger().debug("RpcEndpoint starting");
+  Logger()->debug("RpcEndpoint starting");
   if (is_running_.exchange(true)) {
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kClientError, "RPC endpoint is already running");
@@ -83,7 +83,7 @@ auto RpcEndpoint::Shutdown() -> asio::awaitable<std::expected<void, RpcError>> {
   co_await asio::post(endpoint_strand_, asio::use_awaitable);
   cancel_signal_.emit(asio::cancellation_type::all);
 
-  Logger().debug("Shutting down RPC endpoint");
+  Logger()->debug("Shutting down RPC endpoint");
 
   // Ensure all operations on the strand complete, including message processing
 
@@ -119,7 +119,7 @@ auto RpcEndpoint::SendMethodCall(
   Request request(method, std::move(params), request_id);
   std::string message = request.ToJson().dump();
 
-  Logger().debug("RpcEndpoint sending message: {}", message.substr(0, 70));
+  Logger()->debug("RpcEndpoint sending message: {}", message.substr(0, 70));
   auto pending_request = std::make_shared<PendingRequest>(endpoint_strand_);
   asio::post(endpoint_strand_, [this, request_id, pending_request] {
     pending_requests_[request_id] = pending_request;
@@ -143,7 +143,7 @@ auto RpcEndpoint::SendMethodCall(
 auto RpcEndpoint::SendNotification(
     std::string method, std::optional<nlohmann::json> params)
     -> asio::awaitable<std::expected<void, RpcError>> {
-  Logger().debug("RpcEndpoint sending notification: {}", method);
+  Logger()->debug("RpcEndpoint sending notification: {}", method);
   if (!is_running_) {
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kClientError, "RpcEndpoint is not running");
@@ -152,7 +152,7 @@ auto RpcEndpoint::SendNotification(
   Request request(method, std::move(params));
   std::string message = request.ToJson().dump();
 
-  Logger().debug("RpcEndpoint sending message: {}", message.substr(0, 70));
+  Logger()->debug("RpcEndpoint sending message: {}", message.substr(0, 70));
   auto send_result = co_await transport_->SendMessage(message);
   if (!send_result) {
     co_return send_result;
@@ -177,11 +177,11 @@ auto RpcEndpoint::HasPendingRequests() const -> bool {
 }
 
 void RpcEndpoint::StartMessageProcessing() {
-  Logger().debug("RpcEndpoint starting message processing");
+  Logger()->debug("RpcEndpoint starting message processing");
   message_loop_ = asio::co_spawn(
       endpoint_strand_,
       [this] {
-        Logger().debug(
+        Logger()->debug(
             "RpcEndpoint starting message processing, is_running_: {}",
             is_running_.load());
         return this->ProcessMessagesLoop(cancel_signal_.slot());
@@ -203,14 +203,14 @@ auto RpcEndpoint::ProcessMessagesLoop(asio::cancellation_slot slot)
   while (is_running_ && !state.cancelled()) {
     auto message_result = co_await transport_->ReceiveMessage();
     if (!message_result) {
-      Logger().error("Receive error: {}", message_result.error().Message());
+      Logger()->error("Receive error: {}", message_result.error().Message());
       co_await RetryDelay(executor_);
       continue;
     }
 
     auto handle_result = co_await HandleMessage(*message_result);
     if (!handle_result) {
-      Logger().error("Handle error: {}", handle_result.error().Message());
+      Logger()->error("Handle error: {}", handle_result.error().Message());
       co_await RetryDelay(executor_);
       continue;
     }
@@ -226,7 +226,7 @@ auto IsResponse(const nlohmann::json &msg) -> bool {
 
 auto RpcEndpoint::HandleMessage(std::string message)
     -> asio::awaitable<std::expected<void, RpcError>> {
-  Logger().debug("RpcEndpoint handling message: {}", message.substr(0, 70));
+  Logger()->debug("RpcEndpoint handling message: {}", message.substr(0, 70));
   const auto json_message_result =
       nlohmann::json::parse(message, nullptr, false);
   if (json_message_result.is_discarded()) {

--- a/src/transport/framed_pipe_transport.cpp
+++ b/src/transport/framed_pipe_transport.cpp
@@ -9,8 +9,8 @@ using error::RpcErrorCode;
 
 FramedPipeTransport::FramedPipeTransport(
     asio::any_io_executor executor, const std::string& socket_path,
-    bool is_server)
-    : PipeTransport(std::move(executor), socket_path, is_server) {
+    bool is_server, std::shared_ptr<spdlog::logger> logger)
+    : PipeTransport(std::move(executor), socket_path, is_server, logger) {
 }
 
 auto FramedPipeTransport::SendMessage(std::string message)

--- a/src/transport/framed_pipe_transport.cpp
+++ b/src/transport/framed_pipe_transport.cpp
@@ -30,7 +30,7 @@ auto FramedPipeTransport::ReceiveMessage()
     }
 
     if (!result.error.empty()) {
-      Logger().error("Framing error: {}", result.error);
+      Logger()->error("Framing error: {}", result.error);
       co_return RpcError::UnexpectedFromCode(
           RpcErrorCode::kTransportError, "Framing error: " + result.error);
     }

--- a/src/transport/pipe_transport.cpp
+++ b/src/transport/pipe_transport.cpp
@@ -27,68 +27,68 @@ PipeTransport::PipeTransport(
 
 PipeTransport::~PipeTransport() {
   if (!is_closed_) {
-    Logger().debug("PipeTransport destructor triggering CloseNow()");
+    Logger()->debug("PipeTransport destructor triggering CloseNow()");
     try {
       CloseNow();
     } catch (const std::exception &e) {
-      Logger().error("PipeTransport destructor error: {}", e.what());
+      Logger()->error("PipeTransport destructor error: {}", e.what());
     }
   }
 }
 
 auto PipeTransport::Start()
     -> asio::awaitable<std::expected<void, error::RpcError>> {
-  Logger().debug("PipeTransport starting");
+  Logger()->debug("PipeTransport starting");
   co_await asio::post(GetStrand(), asio::use_awaitable);
 
   if (is_started_) {
-    Logger().debug("PipeTransport already started");
+    Logger()->debug("PipeTransport already started");
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError, "PipeTransport already started");
   }
 
   if (is_closed_) {
-    Logger().error("PipeTransport cannot start a closed transport");
+    Logger()->error("PipeTransport cannot start a closed transport");
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError, "Cannot start a closed transport");
   }
 
   if (is_server_) {
     // For server, bind and listen for connections
-    Logger().debug("PipeTransport starting server at {}", socket_path_);
+    Logger()->debug("PipeTransport starting server at {}", socket_path_);
     auto result = co_await BindAndListen();
     if (!result) {
-      Logger().error(
+      Logger()->error(
           "PipeTransport server error starting at {}: {}", socket_path_,
           result.error().Message());
       co_return result;
     }
   } else {
     // For client, connect to the server
-    Logger().debug("PipeTransport connecting client to {}", socket_path_);
+    Logger()->debug("PipeTransport connecting client to {}", socket_path_);
     auto result = co_await Connect();
     if (!result) {
-      Logger().error(
+      Logger()->error(
           "PipeTransport client error connecting to {}: {}", socket_path_,
           result.error().Message());
       co_return result;
     }
   }
-  Logger().debug("PipeTransport client connected to {}", socket_path_);
+  Logger()->debug("PipeTransport client connected to {}", socket_path_);
 
   // Set started flag before performing operations
   is_started_ = true;
-  Logger().debug("PipeTransport successfully started");
+  Logger()->debug("PipeTransport successfully started");
   co_return Ok();
 }
 
 auto PipeTransport::Close()
     -> asio::awaitable<std::expected<void, error::RpcError>> {
-  Logger().debug("PipeTransport closing");
+  Logger()->debug("PipeTransport closing");
   co_await asio::post(GetStrand(), asio::use_awaitable);
 
   if (is_closed_) {
-    Logger().debug("PipeTransport already closed");
+    Logger()->debug("PipeTransport already closed");
     co_return Ok();
   }
 
@@ -100,11 +100,11 @@ auto PipeTransport::Close()
   if (socket_.is_open()) {
     socket_.cancel(ec);
     if (ec) {
-      Logger().warn("PipeTransport error canceling socket: {}", ec.message());
+      Logger()->warn("PipeTransport error canceling socket: {}", ec.message());
     }
     socket_.close(ec);
     if (ec) {
-      Logger().warn("PipeTransport error closing socket: {}", ec.message());
+      Logger()->warn("PipeTransport error closing socket: {}", ec.message());
     }
   }
 
@@ -112,11 +112,12 @@ auto PipeTransport::Close()
   if (is_server_ && acceptor_) {
     acceptor_->cancel(ec);
     if (ec) {
-      Logger().warn("PipeTransport error canceling acceptor: {}", ec.message());
+      Logger()->warn(
+          "PipeTransport error canceling acceptor: {}", ec.message());
     }
     acceptor_->close(ec);
     if (ec) {
-      Logger().warn("PipeTransport error closing acceptor: {}", ec.message());
+      Logger()->warn("PipeTransport error closing acceptor: {}", ec.message());
     }
   }
 
@@ -124,13 +125,13 @@ auto PipeTransport::Close()
   if (is_server_ && !socket_path_.empty()) {
     auto result = RemoveExistingSocketFile();
     if (!result) {
-      Logger().warn(
+      Logger()->warn(
           "PipeTransport error removing socket file: {}",
           result.error().Message());
     }
   }
 
-  Logger().debug("PipeTransport closed");
+  Logger()->debug("PipeTransport closed");
   co_return Ok();
 }
 
@@ -142,13 +143,13 @@ void PipeTransport::CloseNow() {
     if (!socket_.is_open()) {
       return;
     }
-    Logger().debug("PipeTransport closing socket synchronously");
+    Logger()->debug("PipeTransport closing socket synchronously");
 
     std::error_code ec;
     socket_.cancel();
     socket_.close(ec);
     if (ec) {
-      Logger().warn("PipeTransport error closing socket: {}", ec.message());
+      Logger()->warn("PipeTransport error closing socket: {}", ec.message());
     }
   };
 
@@ -156,13 +157,13 @@ void PipeTransport::CloseNow() {
     if (!is_server_ || !acceptor_ || !acceptor_->is_open()) {
       return;
     }
-    Logger().debug("PipeTransport closing acceptor synchronously");
+    Logger()->debug("PipeTransport closing acceptor synchronously");
 
     std::error_code ec;
     acceptor_->cancel();
     acceptor_->close(ec);
     if (ec) {
-      Logger().warn("PipeTransport error closing acceptor: {}", ec.message());
+      Logger()->warn("PipeTransport error closing acceptor: {}", ec.message());
     }
   };
 
@@ -175,13 +176,13 @@ void PipeTransport::CloseNow() {
     if (std::filesystem::exists(socket_path_, ec) && !ec) {
       std::filesystem::remove(socket_path_, ec);
       if (ec) {
-        Logger().warn(
+        Logger()->warn(
             "PipeTransport error removing socket file: {}", ec.message());
       } else {
-        Logger().debug("PipeTransport removed socket file: {}", socket_path_);
+        Logger()->debug("PipeTransport removed socket file: {}", socket_path_);
       }
     } else if (ec) {
-      Logger().warn(
+      Logger()->warn(
           "PipeTransport error checking socket file existence: {}",
           ec.message());
     }
@@ -192,7 +193,7 @@ void PipeTransport::CloseNow() {
     try_close_acceptor();
     try_remove_socket_file();
   } catch (const std::exception &e) {
-    Logger().error("PipeTransport error during CloseNow(): {}", e.what());
+    Logger()->error("PipeTransport error during CloseNow(): {}", e.what());
   }
 }
 
@@ -215,10 +216,10 @@ auto PipeTransport::RemoveExistingSocketFile()
           RpcErrorCode::kTransportError,
           "Error removing socket file: " + ec.message());
     }
-    Logger().debug(
+    Logger()->debug(
         "PipeTransport removed existing socket file: {}", socket_path_);
   } else {
-    Logger().debug(
+    Logger()->debug(
         "PipeTransport no existing socket file to remove: {}", socket_path_);
   }
   return {};
@@ -251,7 +252,7 @@ auto PipeTransport::SendMessage(std::string message)
       socket_, asio::buffer(message),
       asio::redirect_error(asio::use_awaitable, ec));
   if (ec) {
-    Logger().error("PipeTransport error sending message: {}", ec.message());
+    Logger()->error("PipeTransport error sending message: {}", ec.message());
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError,
         "Error sending message: " + ec.message());
@@ -265,7 +266,7 @@ auto PipeTransport::ReceiveMessage()
   co_await asio::post(GetStrand(), asio::use_awaitable);
 
   if (is_closed_) {
-    Logger().warn(
+    Logger()->warn(
         "PipeTransport ReceiveMessage called after transport was closed");
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError,
@@ -279,7 +280,7 @@ auto PipeTransport::ReceiveMessage()
   }
 
   if (!socket_.is_open()) {
-    Logger().warn("PipeTransport ReceiveMessage called on a closed socket");
+    Logger()->warn("PipeTransport ReceiveMessage called on a closed socket");
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError,
         "ReceiveMessage called on a closed socket");
@@ -294,16 +295,17 @@ auto PipeTransport::ReceiveMessage()
 
   if (ec) {
     if (ec == asio::error::eof) {
-      Logger().debug("PipeTransport connection closed by peer (EOF)");
+      Logger()->debug("PipeTransport connection closed by peer (EOF)");
       is_connected_ = false;
       co_return RpcError::UnexpectedFromCode(
           RpcErrorCode::kTransportError, "Connection closed by peer");
     } else if (ec == asio::error::operation_aborted) {
-      Logger().debug("PipeTransport Receive operation aborted");
+      Logger()->debug("PipeTransport Receive operation aborted");
       co_return RpcError::UnexpectedFromCode(
           RpcErrorCode::kTransportError, "Receive aborted");
     } else {
-      Logger().error("PipeTransport error receiving message: {}", ec.message());
+      Logger()->error(
+          "PipeTransport error receiving message: {}", ec.message());
       co_return RpcError::UnexpectedFromCode(
           RpcErrorCode::kTransportError, "Receive error: " + ec.message());
     }
@@ -321,13 +323,13 @@ auto PipeTransport::ReceiveMessage()
   }
   std::ranges::replace(log_message, '\n', ' ');
   std::ranges::replace(log_message, '\r', ' ');
-  Logger().debug("PipeTransport received message: {}", log_message);
+  Logger()->debug("PipeTransport received message: {}", log_message);
   co_return std::move(message_buffer_);
 }
 
 auto PipeTransport::Connect()
     -> asio::awaitable<std::expected<void, error::RpcError>> {
-  Logger().debug("PipeTransport connecting to {}", socket_path_);
+  Logger()->debug("PipeTransport connecting to {}", socket_path_);
 
   // Make sure we're not already connected
   if (is_connected_) {
@@ -345,7 +347,7 @@ auto PipeTransport::Connect()
   if (socket_.is_open()) {
     socket_.close(ec);
     if (ec) {
-      Logger().warn(
+      Logger()->warn(
           "PipeTransport error closing socket before reconnect: {}",
           ec.message());
     }
@@ -359,25 +361,25 @@ auto PipeTransport::Connect()
   co_await socket_.async_connect(
       endpoint, asio::redirect_error(asio::use_awaitable, ec));
   if (ec) {
-    Logger().error(
+    Logger()->error(
         "PipeTransport error connecting to {}: {}", socket_path_, ec.message());
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError, "Error connecting to: " + ec.message());
   }
 
   is_connected_ = true;
-  Logger().debug("PipeTransport connected to {}", socket_path_);
+  Logger()->debug("PipeTransport connected to {}", socket_path_);
 
   co_return Ok();
 }
 
 auto PipeTransport::BindAndListen()
     -> asio::awaitable<std::expected<void, error::RpcError>> {
-  Logger().debug("PipeTransport binding to {}", socket_path_);
+  Logger()->debug("PipeTransport binding to {}", socket_path_);
 
   auto result = RemoveExistingSocketFile();
   if (!result) {
-    Logger().error(
+    Logger()->error(
         "PipeTransport error removing existing socket file: {}",
         result.error().Message());
     co_return result;
@@ -396,21 +398,21 @@ auto PipeTransport::BindAndListen()
   std::error_code ec;
   acceptor_->open(endpoint.protocol(), ec);
   if (ec) {
-    Logger().error("PipeTransport error opening acceptor: {}", ec.message());
+    Logger()->error("PipeTransport error opening acceptor: {}", ec.message());
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError,
         "Error opening acceptor: " + ec.message());
   }
   acceptor_->bind(endpoint, ec);
   if (ec) {
-    Logger().error("PipeTransport error binding acceptor: {}", ec.message());
+    Logger()->error("PipeTransport error binding acceptor: {}", ec.message());
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError,
         "Error binding acceptor: " + ec.message());
   }
   acceptor_->listen(asio::socket_base::max_listen_connections, ec);
   if (ec) {
-    Logger().error(
+    Logger()->error(
         "PipeTransport error listening on acceptor: {}", ec.message());
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError,
@@ -418,18 +420,18 @@ auto PipeTransport::BindAndListen()
   }
 
   // Accept a connection
-  Logger().debug("PipeTransport waiting for connection on {}", socket_path_);
+  Logger()->debug("PipeTransport waiting for connection on {}", socket_path_);
   co_await acceptor_->async_accept(
       socket_, asio::redirect_error(asio::use_awaitable, ec));
   if (ec) {
-    Logger().error(
+    Logger()->error(
         "PipeTransport error accepting connection: {}", ec.message());
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError,
         "Error accepting connection: " + ec.message());
   }
   is_connected_ = true;
-  Logger().debug("PipeTransport accepted connection on {}", socket_path_);
+  Logger()->debug("PipeTransport accepted connection on {}", socket_path_);
 
   co_return Ok();
 }

--- a/src/transport/pipe_transport.cpp
+++ b/src/transport/pipe_transport.cpp
@@ -17,8 +17,9 @@ using error::RpcError;
 using error::RpcErrorCode;
 
 PipeTransport::PipeTransport(
-    asio::any_io_executor executor, std::string socket_path, bool is_server)
-    : Transport(std::move(executor)),
+    asio::any_io_executor executor, std::string socket_path, bool is_server,
+    std::shared_ptr<spdlog::logger> logger)
+    : Transport(std::move(executor), logger),
       socket_(GetExecutor()),
       socket_path_(std::move(socket_path)),
       is_server_(is_server),

--- a/src/transport/socket_transport.cpp
+++ b/src/transport/socket_transport.cpp
@@ -21,28 +21,28 @@ SocketTransport::SocketTransport(
 
 SocketTransport::~SocketTransport() {
   if (!is_closed_) {
-    Logger().debug("SocketTransport destructor triggering CloseNow()");
+    Logger()->debug("SocketTransport destructor triggering CloseNow()");
     try {
       CloseNow();
     } catch (const std::exception &e) {
-      Logger().error("SocketTransport destructor error: {}", e.what());
+      Logger()->error("SocketTransport destructor error: {}", e.what());
     }
   }
 }
 
 auto SocketTransport::Start()
     -> asio::awaitable<std::expected<void, error::RpcError>> {
-  Logger().debug("SocketTransport starting");
+  Logger()->debug("SocketTransport starting");
   co_await asio::post(GetStrand(), asio::use_awaitable);
 
   if (is_started_) {
-    Logger().debug("SocketTransport already started");
+    Logger()->debug("SocketTransport already started");
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError, "SocketTransport already started");
   }
 
   if (is_closed_) {
-    Logger().error("SocketTransport cannot start a closed transport");
+    Logger()->error("SocketTransport cannot start a closed transport");
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError, "Cannot start a closed transport");
   }
@@ -50,58 +50,60 @@ auto SocketTransport::Start()
   std::expected<void, error::RpcError> result;
 
   if (is_server_) {
-    Logger().debug("SocketTransport starting server at {}:{}", address_, port_);
+    Logger()->debug(
+        "SocketTransport starting server at {}:{}", address_, port_);
     result = co_await BindAndListen();
     if (!result) {
-      Logger().error(
+      Logger()->error(
           "SocketTransport error starting server: {}",
           result.error().Message());
       co_return result;
     }
   } else {
-    Logger().debug(
+    Logger()->debug(
         "Connecting SocketTransport client to {}:{}", address_, port_);
     result = co_await Connect();
     if (!result) {
-      Logger().error(
+      Logger()->error(
           "SocketTransport error connecting client: {}",
           result.error().Message());
       co_return result;
     }
-    Logger().debug(
+    Logger()->debug(
         "SocketTransport client connected to {}:{}", address_, port_);
   }
 
   is_started_ = true;
-  Logger().debug("SocketTransport successfully started");
+  Logger()->debug("SocketTransport successfully started");
   co_return Ok();
 }
 
 auto SocketTransport::Close()
     -> asio::awaitable<std::expected<void, error::RpcError>> {
-  Logger().debug("SocketTransport closing");
+  Logger()->debug("SocketTransport closing");
   co_await asio::post(GetStrand(), asio::use_awaitable);
 
   if (is_closed_) {
-    Logger().debug("SocketTransport already closed");
+    Logger()->debug("SocketTransport already closed");
     co_return std::expected<void, error::RpcError>{};
   }
 
   is_closed_ = true;
   is_connected_ = false;
 
-  Logger().debug("SocketTransport closing");
+  Logger()->debug("SocketTransport closing");
 
   // Cancel and close the socket safely
   std::error_code ec;
   if (socket_.is_open()) {
     socket_.cancel(ec);
     if (ec) {
-      Logger().warn("SocketTransport error canceling socket: {}", ec.message());
+      Logger()->warn(
+          "SocketTransport error canceling socket: {}", ec.message());
     }
     socket_.close(ec);
     if (ec) {
-      Logger().warn("SocketTransport error closing socket: {}", ec.message());
+      Logger()->warn("SocketTransport error closing socket: {}", ec.message());
     }
   }
 
@@ -109,16 +111,17 @@ auto SocketTransport::Close()
   if (is_server_ && acceptor_) {
     acceptor_->cancel(ec);
     if (ec) {
-      Logger().warn(
+      Logger()->warn(
           "SocketTransport error canceling acceptor: {}", ec.message());
     }
     acceptor_->close(ec);
     if (ec) {
-      Logger().warn("SocketTransport error closing acceptor: {}", ec.message());
+      Logger()->warn(
+          "SocketTransport error closing acceptor: {}", ec.message());
     }
   }
 
-  Logger().debug("SocketTransport closed");
+  Logger()->debug("SocketTransport closed");
   co_return Ok();
 }
 
@@ -130,13 +133,13 @@ void SocketTransport::CloseNow() {
     if (!socket_.is_open()) {
       return;
     }
-    Logger().debug("SocketTransport closing socket synchronously");
+    Logger()->debug("SocketTransport closing socket synchronously");
 
     std::error_code ec;
     socket_.cancel();
     socket_.close(ec);
     if (ec) {
-      Logger().warn("SocketTransport error closing socket: {}", ec.message());
+      Logger()->warn("SocketTransport error closing socket: {}", ec.message());
     }
   };
 
@@ -144,13 +147,14 @@ void SocketTransport::CloseNow() {
     if (!is_server_ || !acceptor_ || !acceptor_->is_open()) {
       return;
     }
-    Logger().debug("SocketTransport closing acceptor synchronously");
+    Logger()->debug("SocketTransport closing acceptor synchronously");
 
     std::error_code ec;
     acceptor_->cancel();
     acceptor_->close(ec);
     if (ec) {
-      Logger().warn("SocketTransport error closing acceptor: {}", ec.message());
+      Logger()->warn(
+          "SocketTransport error closing acceptor: {}", ec.message());
     }
   };
 
@@ -158,7 +162,7 @@ void SocketTransport::CloseNow() {
     try_close_socket();
     try_close_acceptor();
   } catch (const std::exception &e) {
-    Logger().error("SocketTransport error during CloseNow(): {}", e.what());
+    Logger()->error("SocketTransport error during CloseNow(): {}", e.what());
   }
 }
 
@@ -192,7 +196,7 @@ auto SocketTransport::SendMessage(std::string message)
       socket_, asio::buffer(message),
       asio::redirect_error(asio::use_awaitable, ec));
   if (ec) {
-    Logger().error("SocketTransport SendMessage failed: {}", ec.message());
+    Logger()->error("SocketTransport SendMessage failed: {}", ec.message());
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError,
         "Error sending message: " + ec.message());
@@ -206,7 +210,7 @@ auto SocketTransport::ReceiveMessage()
   co_await asio::post(GetStrand(), asio::use_awaitable);
 
   if (is_closed_) {
-    Logger().warn(
+    Logger()->warn(
         "SocketTransport ReceiveMessage() called after transport was closed");
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError,
@@ -220,7 +224,7 @@ auto SocketTransport::ReceiveMessage()
   }
 
   if (!socket_.is_open()) {
-    Logger().warn("SocketTransport ReceiveMessage() socket not open");
+    Logger()->warn("SocketTransport ReceiveMessage() socket not open");
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError, "Socket not open in ReceiveMessage()");
   }
@@ -234,16 +238,17 @@ auto SocketTransport::ReceiveMessage()
 
   if (ec) {
     if (ec == asio::error::eof) {
-      Logger().debug("SocketTransport EOF received, connection closed by peer");
+      Logger()->debug(
+          "SocketTransport EOF received, connection closed by peer");
       is_connected_ = false;
       co_return RpcError::UnexpectedFromCode(
           RpcErrorCode::kTransportError, "Connection closed by peer");
     } else if (ec == asio::error::operation_aborted) {
-      Logger().debug("SocketTransport Read operation aborted");
+      Logger()->debug("SocketTransport Read operation aborted");
       co_return RpcError::UnexpectedFromCode(
           RpcErrorCode::kTransportError, "Receive operation aborted");
     } else {
-      Logger().error(
+      Logger()->error(
           "SocketTransport ASIO error in ReceiveMessage(): {}", ec.message());
       co_return RpcError::UnexpectedFromCode(
           RpcErrorCode::kTransportError, "Receive error: " + ec.message());
@@ -256,13 +261,13 @@ auto SocketTransport::ReceiveMessage()
   }
 
   message_buffer_.append(read_buffer_.data(), bytes_read);
-  Logger().debug("SocketTransport received {} bytes", bytes_read);
+  Logger()->debug("SocketTransport received {} bytes", bytes_read);
   co_return std::move(message_buffer_);
 }
 
 auto SocketTransport::Connect()
     -> asio::awaitable<std::expected<void, error::RpcError>> {
-  Logger().debug("SocketTransport connecting to {}:{}", address_, port_);
+  Logger()->debug("SocketTransport connecting to {}:{}", address_, port_);
 
   if (is_connected_) {
     co_return Ok();
@@ -278,7 +283,7 @@ auto SocketTransport::Connect()
   if (socket_.is_open()) {
     socket_.close(ec);
     if (ec) {
-      Logger().warn(
+      Logger()->warn(
           "SocketTransport error closing socket before reconnect: {}",
           ec.message());
     }
@@ -295,7 +300,7 @@ auto SocketTransport::Connect()
       address_, std::to_string(port_),
       asio::redirect_error(asio::use_awaitable, ec));
   if (ec) {
-    Logger().error(
+    Logger()->error(
         "SocketTransport error resolving {}:{}: {}", address_, port_,
         ec.message());
     co_return RpcError::UnexpectedFromCode(
@@ -306,7 +311,7 @@ auto SocketTransport::Connect()
   co_await asio::async_connect(
       socket_, endpoints, asio::redirect_error(asio::use_awaitable, ec));
   if (ec) {
-    Logger().error(
+    Logger()->error(
         "SocketTransport error connecting to {}:{}: {}", address_, port_,
         ec.message());
     if (socket_.is_open()) {
@@ -317,13 +322,13 @@ auto SocketTransport::Connect()
   }
 
   is_connected_ = true;
-  Logger().debug("SocketTransport connected to {}:{}", address_, port_);
+  Logger()->debug("SocketTransport connected to {}:{}", address_, port_);
   co_return Ok();
 }
 
 auto SocketTransport::BindAndListen()
     -> asio::awaitable<std::expected<void, error::RpcError>> {
-  Logger().debug("SocketTransport binding to {}:{}", address_, port_);
+  Logger()->debug("SocketTransport binding to {}:{}", address_, port_);
 
   asio::error_code ec;
 
@@ -337,7 +342,7 @@ auto SocketTransport::BindAndListen()
         address_, std::to_string(port_),
         asio::redirect_error(asio::use_awaitable, ec));
     if (ec) {
-      Logger().error(
+      Logger()->error(
           "SocketTransport error resolving {}:{}: {}", address_, port_,
           ec.message());
       co_return RpcError::UnexpectedFromCode(
@@ -354,14 +359,14 @@ auto SocketTransport::BindAndListen()
   // Create and open acceptor
   acceptor_->open(endpoint.protocol(), ec);
   if (ec) {
-    Logger().error("SocketTransport error opening acceptor: {}", ec.message());
+    Logger()->error("SocketTransport error opening acceptor: {}", ec.message());
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError, "Open error: " + ec.message());
   }
 
   acceptor_->set_option(asio::ip::tcp::acceptor::reuse_address(true), ec);
   if (ec) {
-    Logger().error(
+    Logger()->error(
         "SocketTransport error setting reuse_address: {}", ec.message());
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError, "Set option error: " + ec.message());
@@ -369,32 +374,32 @@ auto SocketTransport::BindAndListen()
 
   acceptor_->bind(endpoint, ec);
   if (ec) {
-    Logger().error("SocketTransport error binding acceptor: {}", ec.message());
+    Logger()->error("SocketTransport error binding acceptor: {}", ec.message());
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError, "Bind error: " + ec.message());
   }
 
   acceptor_->listen(asio::socket_base::max_listen_connections, ec);
   if (ec) {
-    Logger().error("SocketTransport error listening: {}", ec.message());
+    Logger()->error("SocketTransport error listening: {}", ec.message());
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError, "Listen error: " + ec.message());
   }
 
-  Logger().debug("SocketTransport listening on {}:{}", address_, port_);
+  Logger()->debug("SocketTransport listening on {}:{}", address_, port_);
 
   // Accept a connection
   co_await acceptor_->async_accept(
       socket_, asio::redirect_error(asio::use_awaitable, ec));
   if (ec) {
-    Logger().error(
+    Logger()->error(
         "SocketTransport error accepting connection: {}", ec.message());
     co_return RpcError::UnexpectedFromCode(
         RpcErrorCode::kTransportError, "Accept error: " + ec.message());
   }
 
   is_connected_ = true;
-  Logger().debug(
+  Logger()->debug(
       "SocketTransport accepted connection on {}:{}", address_, port_);
 
   co_return Ok();

--- a/src/transport/socket_transport.cpp
+++ b/src/transport/socket_transport.cpp
@@ -10,8 +10,8 @@ using error::RpcErrorCode;
 
 SocketTransport::SocketTransport(
     asio::any_io_executor executor, std::string address, uint16_t port,
-    bool is_server)
-    : Transport(std::move(executor)),
+    bool is_server, std::shared_ptr<spdlog::logger> logger)
+    : Transport(std::move(executor), logger),
       socket_(GetExecutor()),
       address_(std::move(address)),
       port_(port),

--- a/tests/common/mock_transport.hpp
+++ b/tests/common/mock_transport.hpp
@@ -28,7 +28,7 @@ class MockTransport : public jsonrpc::transport::Transport {
   }
 
   ~MockTransport() override {
-    Logger().debug("Destroying mock transport");
+    Logger()->debug("Destroying mock transport");
     CloseNow();
   }
 
@@ -42,19 +42,19 @@ class MockTransport : public jsonrpc::transport::Transport {
     co_await asio::post(strand_, asio::use_awaitable);
 
     if (is_started_) {
-      Logger().debug("MockTransport already started");
+      Logger()->debug("MockTransport already started");
       co_return RpcError::UnexpectedFromCode(
           RpcErrorCode::kTransportError, "MockTransport already started");
     }
 
     if (is_closed_) {
-      Logger().error("Cannot start a closed transport");
+      Logger()->error("Cannot start a closed transport");
       co_return RpcError::UnexpectedFromCode(
           RpcErrorCode::kTransportError, "Cannot start a closed transport");
     }
 
     is_started_ = true;
-    Logger().debug("MockTransport started");
+    Logger()->debug("MockTransport started");
     co_return Ok();
   }
 
@@ -63,10 +63,10 @@ class MockTransport : public jsonrpc::transport::Transport {
     // Get strand protection
     co_await asio::post(strand_, asio::use_awaitable);
 
-    Logger().debug("MockTransport: Closing transport");
+    Logger()->debug("MockTransport: Closing transport");
 
     if (is_closed_) {
-      Logger().debug("MockTransport: Already closed");
+      Logger()->debug("MockTransport: Already closed");
       co_return std::expected<void, error::RpcError>{};
     }
 
@@ -82,7 +82,7 @@ class MockTransport : public jsonrpc::transport::Transport {
           "Failed to cancel receive timer during close: " + ec.message());
     }
 
-    Logger().debug("MockTransport: Closed");
+    Logger()->debug("MockTransport: Closed");
 
     // Optional sync point for strand tasks to flush
     co_await asio::post(strand_, asio::use_awaitable);
@@ -95,7 +95,7 @@ class MockTransport : public jsonrpc::transport::Transport {
     is_started_ = false;
     receive_timer_.cancel();
 
-    Logger().debug("MockTransport closed synchronously");
+    Logger()->debug("MockTransport closed synchronously");
   }
 
   auto SendMessage(std::string message)
@@ -120,7 +120,7 @@ class MockTransport : public jsonrpc::transport::Transport {
   auto ReceiveMessage()
       -> asio::awaitable<std::expected<std::string, error::RpcError>> override {
     if (is_closed_) {
-      Logger().debug(
+      Logger()->debug(
           "MockTransport: ReceiveMessage called after transport was closed");
       co_return RpcError::UnexpectedFromCode(
           RpcErrorCode::kTransportError,
@@ -136,7 +136,7 @@ class MockTransport : public jsonrpc::transport::Transport {
     co_await asio::post(strand_, asio::use_awaitable);
 
     if (is_closed_) {
-      Logger().debug("MockTransport: ReceiveMessage found transport closed");
+      Logger()->debug("MockTransport: ReceiveMessage found transport closed");
       co_return RpcError::UnexpectedFromCode(
           RpcErrorCode::kTransportError,
           "ReceiveMessage called after transport was closed");


### PR DESCRIPTION
## Summary

Refactors all `Logger()` methods to return `std::shared_ptr<spdlog::logger>` instead of references.

## Motivation

This allows logger instances to be passed safely into helper classes (e.g. ScopedTimer) and stored or shared across layers with correct ownership semantics.

## Changes

- Updated all `Logger()` accessors to return `shared_ptr`
- Replaced all `Logger().debug(...)` with `Logger()->debug(...)`
- Ensured all components continue to use a default logger if none is explicitly provided
