### PR TITLE
Fix missing co_return in notification dispatch

### DIFF
--- a/src/endpoint/dispatcher.cpp
+++ b/src/endpoint/dispatcher.cpp
@@ -93,6 +93,7 @@ auto Dispatcher::DispatchSingleRequest(Request request)
             return handler(params);
           },
           asio::detached);
+      co_return std::nullopt;
     }
     Logger()->debug(
         "Dispatcher notification handler not found for method: {}", method);


### PR DESCRIPTION
## Summary

Fixes a bug where notification handler was executed but no value was returned, potentially leading to undefined behavior.

## Changes

- Add missing `co_return std::nullopt;` after launching detached coroutine for notifications.
