### PR TITLE
Fix Compiler error: overloaded functions have similar conversions

### DIFF
--- a/src/endpoint/request.cpp
+++ b/src/endpoint/request.cpp
@@ -38,7 +38,7 @@ auto Request::FromJson(const nlohmann::json& json_obj)
         RpcErrorCode::kInvalidRequest, "Request must be a JSON object");
   }
 
-  if (!json_obj.contains("jsonrpc") || json_obj["jsonrpc"].get<std::string>() != kJsonRpcVersion) {
+  if (!json_obj.contains("jsonrpc") || (json_obj["jsonrpc"].get<std::string>() != kJsonRpcVersion)) {
     return RpcError::UnexpectedFromCode(
         RpcErrorCode::kInvalidRequest, "Missing or invalid 'jsonrpc' version");
   }

--- a/src/endpoint/request.cpp
+++ b/src/endpoint/request.cpp
@@ -38,7 +38,7 @@ auto Request::FromJson(const nlohmann::json& json_obj)
         RpcErrorCode::kInvalidRequest, "Request must be a JSON object");
   }
 
-  if (!json_obj.contains("jsonrpc") || json_obj["jsonrpc"] != kJsonRpcVersion) {
+  if (!json_obj.contains("jsonrpc") || std::string_view(json_obj["jsonrpc"]) != kJsonRpcVersion) {
     return RpcError::UnexpectedFromCode(
         RpcErrorCode::kInvalidRequest, "Missing or invalid 'jsonrpc' version");
   }

--- a/src/endpoint/request.cpp
+++ b/src/endpoint/request.cpp
@@ -38,7 +38,8 @@ auto Request::FromJson(const nlohmann::json& json_obj)
         RpcErrorCode::kInvalidRequest, "Request must be a JSON object");
   }
 
-  if (!json_obj.contains("jsonrpc") || (json_obj["jsonrpc"].get<std::string>() != kJsonRpcVersion)) {
+  if (!json_obj.contains("jsonrpc") ||
+      (json_obj["jsonrpc"].get<std::string>() != kJsonRpcVersion)) {
     return RpcError::UnexpectedFromCode(
         RpcErrorCode::kInvalidRequest, "Missing or invalid 'jsonrpc' version");
   }

--- a/src/endpoint/request.cpp
+++ b/src/endpoint/request.cpp
@@ -38,7 +38,7 @@ auto Request::FromJson(const nlohmann::json& json_obj)
         RpcErrorCode::kInvalidRequest, "Request must be a JSON object");
   }
 
-  if (!json_obj.contains("jsonrpc") || std::string_view(json_obj["jsonrpc"]) != kJsonRpcVersion) {
+  if (!json_obj.contains("jsonrpc") || json_obj["jsonrpc"].get<std::string>() != kJsonRpcVersion) {
     return RpcError::UnexpectedFromCode(
         RpcErrorCode::kInvalidRequest, "Missing or invalid 'jsonrpc' version");
   }

--- a/src/endpoint/response.cpp
+++ b/src/endpoint/response.cpp
@@ -93,7 +93,7 @@ auto Response::ToJson() const -> nlohmann::json {
 auto Response::ValidateResponse() const
     -> std::expected<void, error::RpcError> {
   if (!response_.contains("jsonrpc") ||
-      response_["jsonrpc"] != kJsonRpcVersion) {
+      std::string_view(response_["jsonrpc"]) != kJsonRpcVersion) {
     return RpcError::UnexpectedFromCode(
         RpcErrorCode::kInvalidRequest, "Invalid JSON-RPC version");
   }

--- a/src/endpoint/response.cpp
+++ b/src/endpoint/response.cpp
@@ -93,7 +93,7 @@ auto Response::ToJson() const -> nlohmann::json {
 auto Response::ValidateResponse() const
     -> std::expected<void, error::RpcError> {
   if (!response_.contains("jsonrpc") ||
-      std::string_view(response_["jsonrpc"]) != kJsonRpcVersion) {
+      response_["jsonrpc"].get<std::string>() != kJsonRpcVersion) {
     return RpcError::UnexpectedFromCode(
         RpcErrorCode::kInvalidRequest, "Invalid JSON-RPC version");
   }

--- a/src/endpoint/response.cpp
+++ b/src/endpoint/response.cpp
@@ -93,7 +93,7 @@ auto Response::ToJson() const -> nlohmann::json {
 auto Response::ValidateResponse() const
     -> std::expected<void, error::RpcError> {
   if (!response_.contains("jsonrpc") ||
-      response_["jsonrpc"].get<std::string>() != kJsonRpcVersion) {
+      (response_["jsonrpc"].get<std::string>() != kJsonRpcVersion)) {
     return RpcError::UnexpectedFromCode(
         RpcErrorCode::kInvalidRequest, "Invalid JSON-RPC version");
   }


### PR DESCRIPTION
Fixes: #60 Compiler error: overloaded functions have similar conversions

Added coversion of JSON object member to std::string_view before comparison with other std::string_view